### PR TITLE
fix: address bugs found in production-readiness review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-
+  actions: write
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  actions: write
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.shipsafe.yml
+++ b/.shipsafe.yml
@@ -11,11 +11,11 @@ scanners:
 
   sca:
     enabled: true
-    fail_on_severity: high
+    fail-on-severity: high
 
   secrets:
     enabled: true
-    allow_patterns: []
+    allow-patterns: []
 
 output:
   format: table
@@ -23,4 +23,4 @@ output:
 
 ai:
   triage: false
-  fix_suggestions: false
+  fix-suggestions: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `--lang ja` now localizes table report, scanner progress, and file-output messages
+- GitHub Action no longer swallows the scan exit code; `fail-on` now actually fails the build
+- Config files accept kebab-case keys (`fail-on-severity`, `allow-patterns`, `scan-history`, `fix-suggestions`) as documented in README, with snake_case still supported for backward compatibility
+- `ai-generated-code` SAST rule now uses the bundled ShipSafe rules instead of semgrep's `p/default`
+- `scanners.sca.fail-on-severity` is now honored when computing the exit code (stricter of it and `--fail-on` applies to SCA findings)
+- CI workflow declares least-privilege `permissions` (CodeQL alert)
+- `--lang`, `--config`, and `--verbose` are now global flags, so `shipsafe scan --lang ja` works as documented (previously they were only accepted before the subcommand)
+- `shipsafe init` now writes `version: 1` instead of `version: 0`, and partial config files (omitted sections) fall back to defaults instead of failing to parse
+
 ### Added
 - Initial project structure
 - CLI with `scan`, `init`, `doctor`, `version` commands

--- a/action/action.yml
+++ b/action/action.yml
@@ -84,5 +84,10 @@ runs:
       if: steps.scan.outputs.exit-code != '0'
       shell: bash
       run: |
-        echo "::error::ShipSafe found findings at or above '${{ inputs.fail-on }}' severity (exit code ${{ steps.scan.outputs.exit-code }})"
+        EXIT_CODE="${{ steps.scan.outputs.exit-code }}"
+        if [[ "$EXIT_CODE" == "1" ]]; then
+          echo "::error::ShipSafe found findings at or above '${{ inputs.fail-on }}' severity (exit code $EXIT_CODE)"
+        else
+          echo "::error::ShipSafe scan failed with exit code $EXIT_CODE"
+        fi
         exit 1

--- a/action/action.yml
+++ b/action/action.yml
@@ -60,15 +60,18 @@ runs:
         curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64 -o /usr/local/bin/gitleaks && chmod +x /usr/local/bin/gitleaks
 
     - name: Run ShipSafe Scan
+      id: scan
       shell: bash
       run: |
+        set +e
         shipsafe scan \
           --scanners "${{ inputs.scanners }}" \
           --fail-on "${{ inputs.fail-on }}" \
           --format "${{ inputs.format }}" \
           --lang "${{ inputs.lang }}" \
           --config "${{ inputs.config }}" \
-          --output shipsafe-results.sarif || true
+          --output shipsafe-results.sarif
+        echo "exit-code=$?" >> "$GITHUB_OUTPUT"
 
     - name: Upload SARIF to GitHub Security
       if: inputs.format == 'sarif'
@@ -76,3 +79,10 @@ runs:
       with:
         sarif_file: shipsafe-results.sarif
       continue-on-error: true
+
+    - name: Enforce fail-on threshold
+      if: steps.scan.outputs.exit-code != '0'
+      shell: bash
+      run: |
+        echo "::error::ShipSafe found findings at or above '${{ inputs.fail-on }}' severity (exit code ${{ steps.scan.outputs.exit-code }})"
+        exit 1

--- a/action/action.yml
+++ b/action/action.yml
@@ -85,9 +85,9 @@ runs:
       shell: bash
       run: |
         EXIT_CODE="${{ steps.scan.outputs.exit-code }}"
-        if [[ "$EXIT_CODE" == "1" ]]; then
-          echo "::error::ShipSafe found findings at or above '${{ inputs.fail-on }}' severity (exit code $EXIT_CODE)"
+        if [ "$EXIT_CODE" = "1" ]; then
+          echo "::error::ShipSafe found findings at or above '${{ inputs.fail-on }}' severity"
         else
-          echo "::error::ShipSafe scan failed with exit code $EXIT_CODE"
+          echo "::error::ShipSafe scan failed to run (exit code $EXIT_CODE)"
         fi
         exit 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,15 @@ ai:
     }
 
     #[test]
+    fn test_missing_version_defaults_to_1() {
+        // Container-level #[serde(default)] fills missing fields from the
+        // struct's Default impl, so a partial config gets version: 1.
+        let config: Config = serde_yaml::from_str("scanners: {}").unwrap();
+        assert_eq!(config.version, 1);
+        assert!(config.scanners.sast.enabled);
+    }
+
+    #[test]
     fn test_default_config_serializes_kebab_case() {
         let yaml = serde_yaml::to_string(&Config::default()).unwrap();
         assert!(yaml.contains("fail-on-severity"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub version: u32,
     pub scanners: ScannersConfig,
@@ -11,8 +12,20 @@ pub struct Config {
     #[serde(skip)]
     pub lang: String,
 }
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            scanners: ScannersConfig::default(),
+            output: OutputConfig::default(),
+            ai: AiConfig::default(),
+            lang: String::new(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ScannersConfig {
     pub sast: SastConfig,
     pub sca: ScaConfig,
@@ -20,6 +33,7 @@ pub struct ScannersConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct SastConfig {
     pub enabled: bool,
     pub languages: Vec<String>,
@@ -38,8 +52,10 @@ impl Default for SastConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct ScaConfig {
     pub enabled: bool,
+    #[serde(alias = "fail_on_severity")]
     pub fail_on_severity: String,
 }
 impl Default for ScaConfig {
@@ -52,10 +68,12 @@ impl Default for ScaConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct SecretsConfig {
     pub enabled: bool,
+    #[serde(alias = "allow_patterns")]
     pub allow_patterns: Vec<String>,
-    #[serde(default)]
+    #[serde(default, alias = "scan_history")]
     pub scan_history: bool,
 }
 impl Default for SecretsConfig {
@@ -69,6 +87,7 @@ impl Default for SecretsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct OutputConfig {
     pub format: String,
     pub lang: String,
@@ -83,8 +102,10 @@ impl Default for OutputConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct AiConfig {
     pub triage: bool,
+    #[serde(alias = "fix_suggestions")]
     pub fix_suggestions: bool,
 }
 
@@ -105,4 +126,65 @@ pub fn init_config() -> Result<()> {
     let yaml = serde_yaml::to_string(&Config::default())?;
     std::fs::write(".shipsafe.yml", yaml)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_kebab_case_config() {
+        let yaml = r#"
+version: 1
+scanners:
+  sca:
+    enabled: true
+    fail-on-severity: medium
+  secrets:
+    enabled: true
+    allow-patterns:
+      - "EXAMPLE_.*"
+    scan-history: true
+ai:
+  triage: true
+  fix-suggestions: true
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.scanners.sca.fail_on_severity, "medium");
+        assert_eq!(config.scanners.secrets.allow_patterns, vec!["EXAMPLE_.*"]);
+        assert!(config.scanners.secrets.scan_history);
+        assert!(config.ai.fix_suggestions);
+    }
+
+    #[test]
+    fn test_parse_snake_case_config_backward_compat() {
+        let yaml = r#"
+version: 1
+scanners:
+  sca:
+    enabled: true
+    fail_on_severity: low
+  secrets:
+    enabled: true
+    allow_patterns:
+      - "TEST_.*"
+    scan_history: true
+ai:
+  triage: false
+  fix_suggestions: true
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.scanners.sca.fail_on_severity, "low");
+        assert_eq!(config.scanners.secrets.allow_patterns, vec!["TEST_.*"]);
+        assert!(config.scanners.secrets.scan_history);
+        assert!(config.ai.fix_suggestions);
+    }
+
+    #[test]
+    fn test_default_config_serializes_kebab_case() {
+        let yaml = serde_yaml::to_string(&Config::default()).unwrap();
+        assert!(yaml.contains("fail-on-severity"));
+        assert!(yaml.contains("allow-patterns"));
+        assert!(!yaml.contains("fail_on_severity"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,15 +19,15 @@ struct Cli {
     command: Commands,
 
     /// 設定ファイルのパス
-    #[arg(short, long, default_value = ".shipsafe.yml")]
+    #[arg(short, long, global = true, default_value = ".shipsafe.yml")]
     config: PathBuf,
 
     /// 出力言語 (en, ja)
-    #[arg(long, default_value = "en")]
+    #[arg(long, global = true, default_value = "en")]
     lang: String,
 
     /// 詳細ログを出力
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     verbose: bool,
 }
 
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
 
             reporters::report(&results, &format, output.as_deref(), &config)?;
 
-            let exit_code = results.max_severity_exit_code(&fail_on);
+            let exit_code = results.max_severity_exit_code(&fail_on, &config);
             if exit_code > 0 {
                 std::process::exit(exit_code);
             }

--- a/src/reporters/mod.rs
+++ b/src/reporters/mod.rs
@@ -24,7 +24,11 @@ pub fn report(
 
     if let Some(path) = output {
         std::fs::write(path, &content)?;
-        println!("Results written to {}", path.display());
+        if config.lang == "ja" {
+            println!("結果を {} に書き出しました", path.display());
+        } else {
+            println!("Results written to {}", path.display());
+        }
     } else {
         println!("{}", content);
     }

--- a/src/reporters/table.rs
+++ b/src/reporters/table.rs
@@ -2,7 +2,8 @@ use crate::config::Config;
 use crate::scanners::{ScanResults, Severity};
 use colored::Colorize;
 
-pub fn render(results: &ScanResults, _config: &Config) {
+pub fn render(results: &ScanResults, config: &Config) {
+    let ja = config.lang == "ja";
     println!();
 
     for finding in &results.findings {
@@ -23,9 +24,11 @@ pub fn render(results: &ScanResults, _config: &Config) {
         println!("{} {}  {}", icon, severity_str, finding.title.bold());
 
         if let Some(line) = finding.line {
-            println!("   {} {}:{}", "at".dimmed(), finding.file, line);
+            let label = if ja { "場所:" } else { "at" };
+            println!("   {} {}:{}", label.dimmed(), finding.file, line);
         } else if !finding.file.is_empty() {
-            println!("   {} {}", "in".dimmed(), finding.file);
+            let label = if ja { "場所:" } else { "in" };
+            println!("   {} {}", label.dimmed(), finding.file);
         }
 
         if !finding.description.is_empty() {
@@ -41,7 +44,8 @@ pub fn render(results: &ScanResults, _config: &Config) {
         println!();
 
         if let Some(ref fix) = finding.fix_suggestion {
-            println!("   {} {}", "Fix:".green().bold(), fix);
+            let label = if ja { "修正案:" } else { "Fix:" };
+            println!("   {} {}", label.green().bold(), fix);
         }
 
         println!();
@@ -49,13 +53,24 @@ pub fn render(results: &ScanResults, _config: &Config) {
 
     // Summary
     println!("{}", "=".repeat(52));
-    println!(
-        "Summary: {} findings | {} critical | {} high | {} medium | {} low",
-        results.summary.total,
-        results.summary.critical,
-        results.summary.high,
-        results.summary.medium,
-        results.summary.low,
-    );
+    if ja {
+        println!(
+            "集計: 検出 {} 件 | critical {} | high {} | medium {} | low {}",
+            results.summary.total,
+            results.summary.critical,
+            results.summary.high,
+            results.summary.medium,
+            results.summary.low,
+        );
+    } else {
+        println!(
+            "Summary: {} findings | {} critical | {} high | {} medium | {} low",
+            results.summary.total,
+            results.summary.critical,
+            results.summary.high,
+            results.summary.medium,
+            results.summary.low,
+        );
+    }
     println!();
 }

--- a/src/scanners/mod.rs
+++ b/src/scanners/mod.rs
@@ -102,19 +102,44 @@ impl ScanResults {
         };
     }
 
-    pub fn max_severity_exit_code(&self, fail_on: &str) -> i32 {
-        let threshold = match fail_on {
-            "critical" => Severity::Critical,
-            "high" => Severity::High,
-            "medium" => Severity::Medium,
-            "low" => Severity::Low,
-            _ => Severity::Critical,
-        };
-        if self.findings.iter().any(|f| f.severity >= threshold) {
+    /// Exit code based on severity thresholds. SCA findings honor the
+    /// stricter of the global `--fail-on` and `scanners.sca.fail-on-severity`.
+    pub fn max_severity_exit_code(&self, fail_on: &str, config: &Config) -> i32 {
+        let global = parse_severity(fail_on).unwrap_or_else(|| {
+            tracing::warn!(
+                "unknown fail-on value '{}', defaulting to critical",
+                fail_on
+            );
+            Severity::Critical
+        });
+        let sca_threshold = parse_severity(&config.scanners.sca.fail_on_severity)
+            .unwrap_or_else(|| global.clone())
+            .min(global.clone());
+
+        let failed = self.findings.iter().any(|f| {
+            let threshold = if f.scanner == "sca" {
+                &sca_threshold
+            } else {
+                &global
+            };
+            f.severity >= *threshold
+        });
+        if failed {
             1
         } else {
             0
         }
+    }
+}
+
+/// Parse a severity string (as used in `--fail-on` and config files).
+fn parse_severity(s: &str) -> Option<Severity> {
+    match s {
+        "critical" => Some(Severity::Critical),
+        "high" => Some(Severity::High),
+        "medium" => Some(Severity::Medium),
+        "low" => Some(Severity::Low),
+        _ => None,
     }
 }
 
@@ -126,19 +151,19 @@ pub async fn run_all(path: &Path, scanners: &[&str], config: &Config) -> Result<
             "sast" if config.scanners.sast.enabled => {
                 print_scanner_start("SAST");
                 let r = sast::run(path, config).await?;
-                print_scanner_done("SAST", &r);
+                print_scanner_done("SAST", &r, config);
                 results.merge(r);
             }
             "sca" if config.scanners.sca.enabled => {
                 print_scanner_start("SCA");
                 let r = sca::run(path, config).await?;
-                print_scanner_done("SCA", &r);
+                print_scanner_done("SCA", &r, config);
                 results.merge(r);
             }
             "secrets" if config.scanners.secrets.enabled => {
                 print_scanner_start("Secrets");
                 let r = secrets::run(path, config).await?;
-                print_scanner_done("Secrets", &r);
+                print_scanner_done("Secrets", &r, config);
                 results.merge(r);
             }
             _ => {}
@@ -152,10 +177,12 @@ fn print_scanner_start(name: &str) {
     print!("  {} {:<10} ... ", "▶".cyan(), name);
 }
 
-fn print_scanner_done(_name: &str, results: &ScanResults) {
+fn print_scanner_done(_name: &str, results: &ScanResults, config: &Config) {
+    let ja = config.lang == "ja";
     let count = results.summary.total;
     if count == 0 {
-        println!("{}", "0 findings".green());
+        let msg = if ja { "検出 0 件" } else { "0 findings" };
+        println!("{}", msg.green());
     } else {
         let parts: Vec<String> = [
             (results.summary.critical, "critical", "red"),
@@ -167,7 +194,11 @@ fn print_scanner_done(_name: &str, results: &ScanResults) {
         .filter(|(c, _, _)| *c > 0)
         .map(|(c, label, _)| format!("{} {}", c, label))
         .collect();
-        println!("{} findings ({})", count, parts.join(", "));
+        if ja {
+            println!("検出 {} 件 ({})", count, parts.join(", "));
+        } else {
+            println!("{} findings ({})", count, parts.join(", "));
+        }
     }
 }
 
@@ -185,5 +216,79 @@ pub fn check_dependencies() {
             format!("{} Not found", "✘".red())
         };
         println!("  {} {:<12} {}", status, cmd, desc.dimmed());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finding(scanner: &str, severity: Severity) -> Finding {
+        Finding {
+            id: "test".into(),
+            scanner: scanner.into(),
+            severity,
+            title: "test".into(),
+            description: String::new(),
+            file: "test.rs".into(),
+            line: None,
+            cwe: None,
+            cve: None,
+            fix_suggestion: None,
+        }
+    }
+
+    fn results_with(findings: Vec<Finding>) -> ScanResults {
+        let mut r = ScanResults::new();
+        r.findings = findings;
+        r.recalculate_summary();
+        r
+    }
+
+    #[test]
+    fn test_exit_code_global_threshold() {
+        let config = Config::default();
+        let r = results_with(vec![finding("sast", Severity::High)]);
+        assert_eq!(r.max_severity_exit_code("critical", &config), 0);
+        assert_eq!(r.max_severity_exit_code("high", &config), 1);
+        assert_eq!(r.max_severity_exit_code("low", &config), 1);
+    }
+
+    #[test]
+    fn test_exit_code_sca_uses_config_threshold() {
+        // Default ScaConfig.fail_on_severity is "high": an SCA high finding
+        // fails the build even when the global threshold is critical.
+        let config = Config::default();
+        let r = results_with(vec![finding("sca", Severity::High)]);
+        assert_eq!(r.max_severity_exit_code("critical", &config), 1);
+
+        let r_medium = results_with(vec![finding("sca", Severity::Medium)]);
+        assert_eq!(r_medium.max_severity_exit_code("critical", &config), 0);
+    }
+
+    #[test]
+    fn test_exit_code_sca_honors_stricter_global() {
+        // Global --fail-on low is stricter than sca fail-on-severity high.
+        let config = Config::default();
+        let r = results_with(vec![finding("sca", Severity::Low)]);
+        assert_eq!(r.max_severity_exit_code("low", &config), 1);
+    }
+
+    #[test]
+    fn test_exit_code_unknown_fail_on_defaults_to_critical() {
+        let config = Config::default();
+        let r = results_with(vec![finding("sast", Severity::High)]);
+        assert_eq!(r.max_severity_exit_code("bogus", &config), 0);
+        let r_crit = results_with(vec![finding("sast", Severity::Critical)]);
+        assert_eq!(r_crit.max_severity_exit_code("bogus", &config), 1);
+    }
+
+    #[test]
+    fn test_parse_severity() {
+        assert_eq!(parse_severity("critical"), Some(Severity::Critical));
+        assert_eq!(parse_severity("high"), Some(Severity::High));
+        assert_eq!(parse_severity("medium"), Some(Severity::Medium));
+        assert_eq!(parse_severity("low"), Some(Severity::Low));
+        assert_eq!(parse_severity("bogus"), None);
     }
 }

--- a/src/scanners/sast.rs
+++ b/src/scanners/sast.rs
@@ -34,6 +34,31 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
     parse_semgrep_json(&stdout)
 }
 
+/// Bundled semgrep rules for AI-generated code patterns, embedded at build
+/// time so the distributed binary does not depend on the repo layout.
+const AI_GENERATED_CODE_RULES: &str = include_str!("../../rules/sast/ai-generated-code.yml");
+
+/// Materialize the bundled AI-generated-code rules to a temp file so semgrep
+/// can consume them via --config. Writes to a unique staging file first and
+/// renames into place so concurrent invocations never observe a partial file.
+fn ai_generated_code_rules_path() -> std::io::Result<std::path::PathBuf> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static STAGING_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    let path = std::env::temp_dir().join(format!(
+        "shipsafe-{}-ai-generated-code.yml",
+        env!("CARGO_PKG_VERSION")
+    ));
+    let staging = path.with_extension(format!(
+        "yml.{}.{}",
+        std::process::id(),
+        STAGING_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&staging, AI_GENERATED_CODE_RULES)?;
+    std::fs::rename(&staging, &path)?;
+    Ok(path)
+}
+
 /// Build semgrep rule config and exclude arguments.
 fn build_semgrep_args(cmd: &mut Command, config: &Config) {
     // Add rule configs; default to OWASP Top 10 if none specified
@@ -46,9 +71,17 @@ fn build_semgrep_args(cmd: &mut Command, config: &Config) {
                 "owasp-top-10" => {
                     cmd.arg("--config").arg("p/owasp-top-ten");
                 }
-                "ai-generated-code" => {
-                    cmd.arg("--config").arg("p/default");
-                }
+                "ai-generated-code" => match ai_generated_code_rules_path() {
+                    Ok(path) => {
+                        cmd.arg("--config").arg(path);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to materialize bundled ai-generated-code rules, skipping: {}",
+                            e
+                        );
+                    }
+                },
                 other => {
                     cmd.arg("--config").arg(other);
                 }
@@ -348,8 +381,18 @@ mod tests {
 
         let args = get_args(&cmd);
         assert!(args.contains(&"p/owasp-top-ten".to_string()));
-        assert!(args.contains(&"p/default".to_string()));
+        assert!(args
+            .iter()
+            .any(|a| a.ends_with("ai-generated-code.yml") && !a.contains("p/default")));
         assert!(args.contains(&"--exclude".to_string()));
         assert!(args.contains(&"vendor".to_string()));
+    }
+
+    #[test]
+    fn test_ai_generated_code_rules_materialized() {
+        let path = ai_generated_code_rules_path().unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("ai-hardcoded-credentials"));
+        assert!(content.contains("ai-sql-injection"));
     }
 }

--- a/src/scanners/sast.rs
+++ b/src/scanners/sast.rs
@@ -55,9 +55,14 @@ fn ai_generated_code_rules_path() -> std::io::Result<std::path::PathBuf> {
         STAGING_COUNTER.fetch_add(1, Ordering::Relaxed)
     ));
     std::fs::write(&staging, AI_GENERATED_CODE_RULES)?;
-    std::fs::rename(&staging, &path)?;
-    Ok(path)
-}
+    match std::fs::rename(&staging, &path) {
+        Ok(()) => Ok(path),
+        Err(e) if path.is_file() => {
+            let _ = std::fs::remove_file(&staging);
+            Ok(path)
+        }
+        Err(e) => Err(e),
+    }
 
 /// Build semgrep rule config and exclude arguments.
 fn build_semgrep_args(cmd: &mut Command, config: &Config) {

--- a/src/scanners/sast.rs
+++ b/src/scanners/sast.rs
@@ -55,14 +55,17 @@ fn ai_generated_code_rules_path() -> std::io::Result<std::path::PathBuf> {
         STAGING_COUNTER.fetch_add(1, Ordering::Relaxed)
     ));
     std::fs::write(&staging, AI_GENERATED_CODE_RULES)?;
-    match std::fs::rename(&staging, &path) {
-        Ok(()) => Ok(path),
-        Err(e) if path.is_file() => {
-            let _ = std::fs::remove_file(&staging);
-            Ok(path)
+    if let Err(e) = std::fs::rename(&staging, &path) {
+        // The rename can fail if the destination is locked (e.g. on Windows
+        // while another process reads it). The content is identical for a
+        // given version, so an existing destination is safe to reuse.
+        let _ = std::fs::remove_file(&staging);
+        if !path.is_file() {
+            return Err(e);
         }
-        Err(e) => Err(e),
     }
+    Ok(path)
+}
 
 /// Build semgrep rule config and exclude arguments.
 fn build_semgrep_args(cmd: &mut Command, config: &Config) {


### PR DESCRIPTION
## Summary

Fixes 8 bugs/inconsistencies found during a production-readiness review of the repo.

### CLI / config
- **`--lang ja` did nothing**: `config.lang` was loaded but never read. Table report, scanner progress, and file-output messages are now localized for Japanese.
- **`--lang` / `--config` / `--verbose` were not global flags**: `shipsafe scan --lang ja` (the form documented in README and used by the composite action) failed with exit 2. They are now `global = true`.
- **README config examples didn't parse**: README documents kebab-case keys (`fail-on-severity`, `allow-patterns`) but serde expected snake_case, silently ignoring the settings. Config structs now use `rename_all = "kebab-case"` with snake_case aliases for backward compatibility.
- **Partial configs failed to parse**: container-level `serde(default)` lets omitted sections fall back to defaults (zero-config principle). `shipsafe init` now writes `version: 1` instead of `0`.
- **`scanners.sca.fail-on-severity` was unused**: SCA findings now fail the build at the stricter of that threshold and the global `--fail-on`.
- **`ai-generated-code` rule was wired to `p/default`**: it now uses the bundled `rules/sast/ai-generated-code.yml`, embedded at build time and materialized to a temp file (atomic rename) for semgrep.

### CI / Action
- **Action swallowed the scan exit code** (`|| true`), so `fail-on` never failed the build. The exit code is now captured, SARIF is uploaded first, then the threshold is enforced.
- **CI workflow had no `permissions` block** (CodeQL alert no. 2): added least-privilege `contents: read`. Supersedes #40 / #41.

## Test plan
- 42 unit tests (9 new: config kebab/snake parsing, exit-code thresholds, bundled rule materialization) + 1 integration test — all pass
- `cargo clippy -- -D warnings`, `cargo fmt --check` pass
- Smoke-tested: `shipsafe scan --path . --lang ja` (Japanese output, exit 0), `shipsafe init` (kebab-case, version: 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)