### PR TITLE
Japanese localization + fail-on exit code reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,21 +90,61 @@ async fn main() -> anyhow::Result<()> {
 
             reporters::report(&results, &format, output.as_deref(), &config)?;
 
-            let exit_code = results.max_severity_exit_code(&fail_on, &config);
-            if exit_code > 0 {
-                std::process::exit(exit_code);
+            if results.max_severity_exit_code(&fail_on, &config) != 0 {
+                let failing = results.failing_findings(&fail_on, &config);
+                // Surface the failure reason so CI logs explain why the build
+                // failed, not just that it failed.
+                if config.lang == "ja" {
+                    eprintln!(
+                        "{} ビルド失敗: 重要度しきい値 (--fail-on {}) 以上の検出が {} 件あります",
+                        "✘".red().bold(),
+                        fail_on,
+                        failing.len()
+                    );
+                } else {
+                    eprintln!(
+                        "{} Build failed: {} finding(s) at or above the '--fail-on {}' severity threshold",
+                        "✘".red().bold(),
+                        failing.len(),
+                        fail_on
+                    );
+                }
+                for f in failing.iter().take(10) {
+                    let loc = match f.line {
+                        Some(line) => format!("{}:{}", f.file, line),
+                        None => f.file.clone(),
+                    };
+                    eprintln!(
+                        "    [{}] {} ({})",
+                        f.severity.label(&config.lang),
+                        f.title,
+                        loc
+                    );
+                }
+                if failing.len() > 10 {
+                    if config.lang == "ja" {
+                        eprintln!("    ... ほか {} 件", failing.len() - 10);
+                    } else {
+                        eprintln!("    ... and {} more", failing.len() - 10);
+                    }
+                }
+                std::process::exit(1);
             }
         }
 
         Commands::Init => {
             config::init_config()?;
-            println!("{} .shipsafe.yml を作成しました", "✔".green().bold());
+            if cli.lang == "ja" {
+                println!("{} .shipsafe.yml を作成しました", "✔".green().bold());
+            } else {
+                println!("{} Created .shipsafe.yml", "✔".green().bold());
+            }
         }
 
         Commands::Doctor => {
             println!("{}", "ShipSafe Doctor".bold());
             println!();
-            scanners::check_dependencies();
+            scanners::check_dependencies(&cli.lang);
         }
 
         Commands::Version => {

--- a/src/reporters/table.rs
+++ b/src/reporters/table.rs
@@ -7,11 +7,12 @@ pub fn render(results: &ScanResults, config: &Config) {
     println!();
 
     for finding in &results.findings {
+        let label = finding.severity.label(&config.lang);
         let severity_str = match finding.severity {
-            Severity::Critical => "CRITICAL".red().bold().to_string(),
-            Severity::High => "HIGH".yellow().bold().to_string(),
-            Severity::Medium => "MEDIUM".blue().bold().to_string(),
-            Severity::Low => "LOW".dimmed().to_string(),
+            Severity::Critical => label.red().bold().to_string(),
+            Severity::High => label.yellow().bold().to_string(),
+            Severity::Medium => label.blue().bold().to_string(),
+            Severity::Low => label.dimmed().to_string(),
         };
 
         let icon = match finding.severity {
@@ -55,7 +56,7 @@ pub fn render(results: &ScanResults, config: &Config) {
     println!("{}", "=".repeat(52));
     if ja {
         println!(
-            "集計: 検出 {} 件 | critical {} | high {} | medium {} | low {}",
+            "集計: 検出 {} 件 | 重大 {} | 高 {} | 中 {} | 低 {}",
             results.summary.total,
             results.summary.critical,
             results.summary.high,

--- a/src/scanners/mod.rs
+++ b/src/scanners/mod.rs
@@ -48,6 +48,27 @@ impl std::fmt::Display for Severity {
     }
 }
 
+impl Severity {
+    /// Localized severity label. Japanese: 重大/高/中/低.
+    pub fn label(&self, lang: &str) -> &'static str {
+        if lang == "ja" {
+            match self {
+                Severity::Critical => "重大",
+                Severity::High => "高",
+                Severity::Medium => "中",
+                Severity::Low => "低",
+            }
+        } else {
+            match self {
+                Severity::Critical => "CRITICAL",
+                Severity::High => "HIGH",
+                Severity::Medium => "MEDIUM",
+                Severity::Low => "LOW",
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanSummary {
     pub total: usize,
@@ -112,9 +133,9 @@ impl ScanResults {
         };
     }
 
-    /// Exit code based on severity thresholds. SCA findings honor the
+    /// Findings at or above the failure threshold. SCA findings honor the
     /// stricter of the global `--fail-on` and `scanners.sca.fail-on-severity`.
-    pub fn max_severity_exit_code(&self, fail_on: &str, config: &Config) -> i32 {
+    pub fn failing_findings(&self, fail_on: &str, config: &Config) -> Vec<&Finding> {
         let global = parse_severity(fail_on).unwrap_or_else(|| {
             tracing::warn!(
                 "unknown fail-on value '{}', defaulting to critical",
@@ -126,19 +147,23 @@ impl ScanResults {
             .unwrap_or_else(|| global.clone())
             .min(global.clone());
 
-        let failed = self.findings.iter().any(|f| {
-            let threshold = if f.scanner == "sca" {
-                &sca_threshold
-            } else {
-                &global
-            };
-            f.severity >= *threshold
-        });
-        if failed {
-            1
-        } else {
-            0
-        }
+        self.findings
+            .iter()
+            .filter(|f| {
+                let threshold = if f.scanner == "sca" {
+                    &sca_threshold
+                } else {
+                    &global
+                };
+                f.severity >= *threshold
+            })
+            .collect()
+    }
+
+    /// Exit code based on severity thresholds: 1 when any finding is at or
+    /// above the failure threshold, 0 otherwise.
+    pub fn max_severity_exit_code(&self, fail_on: &str, config: &Config) -> i32 {
+        i32::from(!self.failing_findings(fail_on, config).is_empty())
     }
 }
 
@@ -218,14 +243,20 @@ fn print_scanner_done(name: &str, results: &ScanResults, config: &Config) {
         println!("{}{}", prefix, msg.green());
     } else {
         let parts: Vec<String> = [
-            (results.summary.critical, "critical"),
-            (results.summary.high, "high"),
-            (results.summary.medium, "medium"),
-            (results.summary.low, "low"),
+            (results.summary.critical, Severity::Critical),
+            (results.summary.high, Severity::High),
+            (results.summary.medium, Severity::Medium),
+            (results.summary.low, Severity::Low),
         ]
         .iter()
         .filter(|(c, _)| *c > 0)
-        .map(|(c, label)| format!("{} {}", c, label))
+        .map(|(c, sev)| {
+            if ja {
+                format!("{} {} 件", sev.label("ja"), c)
+            } else {
+                format!("{} {}", c, sev.label("en").to_lowercase())
+            }
+        })
         .collect();
         if ja {
             println!("{}検出 {} 件 ({})", prefix, count, parts.join(", "));
@@ -235,18 +266,37 @@ fn print_scanner_done(name: &str, results: &ScanResults, config: &Config) {
     }
 }
 
-pub fn check_dependencies() {
-    let tools = vec![
-        ("semgrep", "SAST scanner"),
-        ("trivy", "SCA / Container / IaC scanner"),
-        ("gitleaks", "Secret scanner"),
-    ];
+pub fn check_dependencies(lang: &str) {
+    let ja = lang == "ja";
+    let tools = if ja {
+        vec![
+            ("semgrep", "SAST スキャナー"),
+            ("trivy", "SCA / コンテナ / IaC スキャナー"),
+            ("gitleaks", "シークレットスキャナー"),
+        ]
+    } else {
+        vec![
+            ("semgrep", "SAST scanner"),
+            ("trivy", "SCA / Container / IaC scanner"),
+            ("gitleaks", "Secret scanner"),
+        ]
+    };
 
     for (cmd, desc) in tools {
         let status = if which::which(cmd).is_ok() {
-            format!("{} Found", "✔".green())
+            let label = if ja {
+                "インストール済み"
+            } else {
+                "Found"
+            };
+            format!("{} {}", "✔".green(), label)
         } else {
-            format!("{} Not found", "✘".red())
+            let label = if ja {
+                "未インストール"
+            } else {
+                "Not found"
+            };
+            format!("{} {}", "✘".red(), label)
         };
         println!("  {} {:<12} {}", status, cmd, desc.dimmed());
     }
@@ -335,6 +385,28 @@ mod tests {
         assert_eq!(r.max_severity_exit_code("bogus", &config), 0);
         let r_crit = results_with(vec![finding("sast", Severity::Critical)]);
         assert_eq!(r_crit.max_severity_exit_code("bogus", &config), 1);
+    }
+
+    #[test]
+    fn test_severity_labels_ja() {
+        assert_eq!(Severity::Critical.label("ja"), "重大");
+        assert_eq!(Severity::High.label("ja"), "高");
+        assert_eq!(Severity::Medium.label("ja"), "中");
+        assert_eq!(Severity::Low.label("ja"), "低");
+        assert_eq!(Severity::Critical.label("en"), "CRITICAL");
+    }
+
+    #[test]
+    fn test_failing_findings_reports_only_threshold_breaches() {
+        let config = Config::default();
+        let r = results_with(vec![
+            finding("sast", Severity::Critical),
+            finding("sast", Severity::High),
+            finding("sast", Severity::Low),
+        ]);
+        assert_eq!(r.failing_findings("critical", &config).len(), 1);
+        assert_eq!(r.failing_findings("high", &config).len(), 2);
+        assert_eq!(r.failing_findings("low", &config).len(), 3);
     }
 
     #[test]

--- a/src/scanners/secrets.rs
+++ b/src/scanners/secrets.rs
@@ -178,6 +178,17 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
         })
         .collect();
 
+    // Write the report to a temp file: /dev/stdout is not writable in some
+    // sandboxed/CI environments, and a real file works everywhere.
+    let report_path = std::env::temp_dir().join(format!(
+        "shipsafe-gitleaks-{}-{}.json",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+
     let mut cmd = Command::new("gitleaks");
     cmd.arg("detect")
         .arg("--source")
@@ -185,7 +196,7 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
         .arg("--report-format")
         .arg("json")
         .arg("--report-path")
-        .arg("/dev/stdout")
+        .arg(&report_path)
         .arg("--no-banner");
 
     // Enable git history scanning
@@ -211,13 +222,18 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
                 exit_code,
                 stderr.lines().next().unwrap_or("(no details)")
             );
+            let _ = std::fs::remove_file(&report_path);
             return Ok(results);
         }
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report = std::fs::read_to_string(&report_path).unwrap_or_else(|e| {
+        tracing::warn!("failed to read gitleaks report: {}", e);
+        String::from("[]")
+    });
+    let _ = std::fs::remove_file(&report_path);
 
-    results.findings = parse_gitleaks_output(&stdout, &allow_patterns);
+    results.findings = parse_gitleaks_output(&report, &allow_patterns);
     results.recalculate_summary();
 
     Ok(results)


### PR DESCRIPTION
## Summary
- **#10 日本語ローカライズ**: 重要度ラベルを日本語化(重大/高/中/低)。table レポーター・スキャナーサマリー・doctor・init メッセージを `--lang ja` で日本語表示。
- **#14 Exit code による CI 制御**: `--fail-on` しきい値超過時に、失敗理由(しきい値・件数・該当 finding 一覧)を stderr に出力し、exit code 1 で終了。CI ログで失敗理由が分かるように。
- gitleaks のレポート出力を `/dev/stdout` から一時ファイルへ変更(サンドボックス/一部 CI コンテナで `/dev/stdout` が書き込み不可のため)。

## Test plan
- `cargo test` (53 tests pass)
- 手動確認: ダミー GitHub PAT を含むディレクトリを `--lang ja scan -s secrets --fail-on high` でスキャンし、日本語出力・失敗理由・exit=1 を確認

Closes #10
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)