### PR TITLE
Custom rule loading, exclude patterns, and shipsafe validate

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,9 @@ pub struct Config {
     pub scanners: ScannersConfig,
     pub output: OutputConfig,
     pub ai: AiConfig,
+    /// Glob patterns excluded from all scanners (matched against finding
+    /// file paths).
+    pub exclude: Vec<String>,
     #[serde(skip)]
     pub lang: String,
 }
@@ -19,6 +22,7 @@ impl Default for Config {
             scanners: ScannersConfig::default(),
             output: OutputConfig::default(),
             ai: AiConfig::default(),
+            exclude: vec![],
             lang: String::new(),
         }
     }
@@ -33,12 +37,18 @@ pub struct ScannersConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct SastConfig {
     pub enabled: bool,
     pub languages: Vec<String>,
     pub rules: Vec<String>,
     pub exclude: Vec<String>,
+    /// Extra rule files or directories passed to semgrep --config.
+    #[serde(alias = "rules_paths")]
+    pub rules_paths: Vec<String>,
+    /// Rule IDs disabled via semgrep --exclude-rule.
+    #[serde(alias = "disabled_rules")]
+    pub disabled_rules: Vec<String>,
 }
 impl Default for SastConfig {
     fn default() -> Self {
@@ -47,6 +57,8 @@ impl Default for SastConfig {
             languages: vec![],
             rules: vec!["owasp-top-10".into()],
             exclude: vec![],
+            rules_paths: vec![],
+            disabled_rules: vec![],
         }
     }
 }
@@ -128,6 +140,171 @@ pub fn init_config() -> Result<()> {
     Ok(())
 }
 
+/// Known config keys per section, accepting both kebab-case and snake_case.
+const KNOWN_KEYS: &[(&str, &[&str])] = &[
+    ("", &["version", "scanners", "output", "ai", "exclude"]),
+    ("scanners", &["sast", "sca", "secrets"]),
+    (
+        "scanners.sast",
+        &[
+            "enabled",
+            "languages",
+            "rules",
+            "exclude",
+            "rules-paths",
+            "rules_paths",
+            "disabled-rules",
+            "disabled_rules",
+        ],
+    ),
+    (
+        "scanners.sca",
+        &["enabled", "fail-on-severity", "fail_on_severity"],
+    ),
+    (
+        "scanners.secrets",
+        &[
+            "enabled",
+            "allow-patterns",
+            "allow_patterns",
+            "scan-history",
+            "scan_history",
+        ],
+    ),
+    ("output", &["format", "lang"]),
+    ("ai", &["triage", "fix-suggestions", "fix_suggestions"]),
+];
+
+fn check_unknown_keys(value: &serde_yaml::Value, section: &str, errors: &mut Vec<String>) {
+    let serde_yaml::Value::Mapping(map) = value else {
+        return;
+    };
+    let Some((_, known)) = KNOWN_KEYS.iter().find(|(s, _)| *s == section) else {
+        return;
+    };
+    for (key, child) in map {
+        let Some(key) = key.as_str() else { continue };
+        if !known.contains(&key) {
+            let path = if section.is_empty() {
+                key.to_string()
+            } else {
+                format!("{}.{}", section, key)
+            };
+            errors.push(format!(
+                "unknown key '{}' (did you mean one of: {}?)",
+                path,
+                known.join(", ")
+            ));
+            continue;
+        }
+        let child_section = if section.is_empty() {
+            key.to_string()
+        } else {
+            format!("{}.{}", section, key)
+        };
+        if KNOWN_KEYS.iter().any(|(s, _)| *s == child_section) {
+            check_unknown_keys(child, &child_section, errors);
+        }
+    }
+}
+
+/// Validate a .shipsafe.yml file. Returns a list of human-readable problems;
+/// an empty list means the config is valid.
+pub fn validate_file(path: &Path) -> Result<Vec<String>> {
+    let mut errors = Vec::new();
+
+    if !path.exists() {
+        errors.push(format!("config file not found: {}", path.display()));
+        return Ok(errors);
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    let value: serde_yaml::Value = match serde_yaml::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            errors.push(format!("invalid YAML: {}", e));
+            return Ok(errors);
+        }
+    };
+
+    check_unknown_keys(&value, "", &mut errors);
+
+    let config: Config = match serde_yaml::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            errors.push(format!("schema error: {}", e));
+            return Ok(errors);
+        }
+    };
+
+    if config.version != 1 {
+        errors.push(format!(
+            "version: expected 1, found {} (only version 1 is supported)",
+            config.version
+        ));
+    }
+
+    const FORMATS: &[&str] = &["table", "json", "sarif"];
+    if !FORMATS.contains(&config.output.format.as_str()) {
+        errors.push(format!(
+            "output.format: '{}' is not one of {}",
+            config.output.format,
+            FORMATS.join(", ")
+        ));
+    }
+
+    const LANGS: &[&str] = &["en", "ja"];
+    if !LANGS.contains(&config.output.lang.as_str()) {
+        errors.push(format!(
+            "output.lang: '{}' is not one of {}",
+            config.output.lang,
+            LANGS.join(", ")
+        ));
+    }
+
+    const SEVERITIES: &[&str] = &["critical", "high", "medium", "low"];
+    if !SEVERITIES.contains(&config.scanners.sca.fail_on_severity.as_str()) {
+        errors.push(format!(
+            "scanners.sca.fail-on-severity: '{}' is not one of {}",
+            config.scanners.sca.fail_on_severity,
+            SEVERITIES.join(", ")
+        ));
+    }
+
+    for pattern in &config.scanners.secrets.allow_patterns {
+        if let Err(e) = regex::Regex::new(pattern) {
+            errors.push(format!(
+                "scanners.secrets.allow-patterns: invalid regex '{}': {}",
+                pattern, e
+            ));
+        }
+    }
+
+    for pattern in &config.exclude {
+        if let Err(e) = glob::Pattern::new(pattern) {
+            errors.push(format!("exclude: invalid glob '{}': {}", pattern, e));
+        }
+    }
+
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    for rules_path in &config.scanners.sast.rules_paths {
+        let p = Path::new(rules_path);
+        let resolved = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            base.join(p)
+        };
+        if !resolved.exists() {
+            errors.push(format!(
+                "scanners.sast.rules-paths: path does not exist: {}",
+                rules_path
+            ));
+        }
+    }
+
+    Ok(errors)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,5 +372,131 @@ ai:
         assert!(yaml.contains("fail-on-severity"));
         assert!(yaml.contains("allow-patterns"));
         assert!(!yaml.contains("fail_on_severity"));
+    }
+
+    fn write_temp_config(content: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "shipsafe-validate-test-{}-{}.yml",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_validate_valid_config() {
+        let path = write_temp_config(
+            r#"
+version: 1
+scanners:
+  sast:
+    enabled: true
+    rules: [owasp-top-10]
+  sca:
+    fail-on-severity: high
+  secrets:
+    allow-patterns: ["EXAMPLE_.*"]
+output:
+  format: table
+  lang: ja
+exclude:
+  - "vendor/**"
+"#,
+        );
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn test_validate_missing_file() {
+        let errors = validate_file(Path::new("/nonexistent/shipsafe.yml")).unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("not found"));
+    }
+
+    #[test]
+    fn test_validate_unknown_key() {
+        let path = write_temp_config("version: 1\nscannres: {}\n");
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors.iter().any(|e| e.contains("unknown key 'scannres'")));
+    }
+
+    #[test]
+    fn test_validate_nested_unknown_key() {
+        let path = write_temp_config("version: 1\nscanners:\n  sast:\n    enabld: true\n");
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("unknown key 'scanners.sast.enabld'")));
+    }
+
+    #[test]
+    fn test_validate_bad_values() {
+        let path = write_temp_config(
+            r#"
+version: 2
+scanners:
+  sca:
+    fail-on-severity: extreme
+  secrets:
+    allow-patterns: ["[invalid"]
+output:
+  format: xml
+  lang: fr
+exclude:
+  - "[bad-glob"
+"#,
+        );
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors.iter().any(|e| e.contains("version")));
+        assert!(errors.iter().any(|e| e.contains("output.format")));
+        assert!(errors.iter().any(|e| e.contains("output.lang")));
+        assert!(errors.iter().any(|e| e.contains("fail-on-severity")));
+        assert!(errors.iter().any(|e| e.contains("invalid regex")));
+        assert!(errors.iter().any(|e| e.contains("invalid glob")));
+    }
+
+    #[test]
+    fn test_validate_invalid_yaml() {
+        let path = write_temp_config(": not yaml :\n  - {");
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors.iter().any(|e| e.contains("invalid YAML")));
+    }
+
+    #[test]
+    fn test_validate_missing_rules_path() {
+        let path = write_temp_config(
+            "version: 1\nscanners:\n  sast:\n    rules-paths:\n      - ./no-such-rules.yml\n",
+        );
+        let errors = validate_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(errors.iter().any(|e| e.contains("does not exist")));
+    }
+
+    #[test]
+    fn test_parse_rules_paths_and_disabled_rules() {
+        let yaml = r#"
+version: 1
+scanners:
+  sast:
+    rules-paths:
+      - ./custom-rules/
+    disabled-rules:
+      - ai-rust-unsafe-block
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.scanners.sast.rules_paths, vec!["./custom-rules/"]);
+        assert_eq!(
+            config.scanners.sast.disabled_rules,
+            vec!["ai-rust-unsafe-block"]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,17 @@ enum Commands {
         /// この重要度以上でビルド失敗 (critical, high, medium, low)
         #[arg(long, default_value = "critical")]
         fail_on: String,
+
+        /// テストディレクトリ・テストファイルを除外
+        #[arg(long)]
+        exclude_tests: bool,
     },
 
     /// 設定ファイルを初期化
     Init,
+
+    /// 設定ファイルを検証
+    Validate,
 
     /// インストールされているスキャナーを確認
     Doctor,
@@ -80,10 +87,17 @@ async fn main() -> anyhow::Result<()> {
             format,
             output,
             fail_on,
+            exclude_tests,
         } => {
             print_banner();
 
-            let config = config::Config::load(&cli.config, &cli.lang)?;
+            let mut config = config::Config::load(&cli.config, &cli.lang)?;
+            if exclude_tests {
+                config
+                    .exclude
+                    .extend(scanners::TEST_EXCLUDE_GLOBS.iter().map(|s| s.to_string()));
+            }
+            let config = config;
             let scanner_list: Vec<&str> = scanners.split(',').map(|s| s.trim()).collect();
 
             let results = scanners::run_all(&path, &scanner_list, &config).await?;
@@ -138,6 +152,46 @@ async fn main() -> anyhow::Result<()> {
                 println!("{} .shipsafe.yml を作成しました", "✔".green().bold());
             } else {
                 println!("{} Created .shipsafe.yml", "✔".green().bold());
+            }
+        }
+
+        Commands::Validate => {
+            let ja = cli.lang == "ja";
+            let errors = config::validate_file(&cli.config)?;
+            if errors.is_empty() {
+                if ja {
+                    println!(
+                        "{} {} は有効な設定です",
+                        "✔".green().bold(),
+                        cli.config.display()
+                    );
+                } else {
+                    println!(
+                        "{} {} is a valid configuration",
+                        "✔".green().bold(),
+                        cli.config.display()
+                    );
+                }
+            } else {
+                if ja {
+                    eprintln!(
+                        "{} {} に {} 件の問題があります:",
+                        "✘".red().bold(),
+                        cli.config.display(),
+                        errors.len()
+                    );
+                } else {
+                    eprintln!(
+                        "{} {} has {} problem(s):",
+                        "✘".red().bold(),
+                        cli.config.display(),
+                        errors.len()
+                    );
+                }
+                for e in &errors {
+                    eprintln!("  - {}", e);
+                }
+                std::process::exit(1);
             }
         }
 

--- a/src/scanners/mod.rs
+++ b/src/scanners/mod.rs
@@ -165,7 +165,56 @@ impl ScanResults {
     pub fn max_severity_exit_code(&self, fail_on: &str, config: &Config) -> i32 {
         i32::from(!self.failing_findings(fail_on, config).is_empty())
     }
+
+    /// Drop findings whose file path matches any of the glob patterns.
+    /// Applies to results from every scanner, so excludes work uniformly
+    /// even for tools without a native exclude flag.
+    pub fn apply_excludes(&mut self, patterns: &[String]) {
+        if patterns.is_empty() {
+            return;
+        }
+        let compiled: Vec<glob::Pattern> = patterns
+            .iter()
+            .filter_map(|p| match glob::Pattern::new(p) {
+                Ok(g) => Some(g),
+                Err(e) => {
+                    tracing::warn!("invalid exclude glob '{}': {}", p, e);
+                    None
+                }
+            })
+            .collect();
+        self.findings.retain(|f| {
+            let normalized = f.file.strip_prefix("./").unwrap_or(&f.file);
+            !compiled.iter().any(|g| g.matches(normalized))
+        });
+        self.recalculate_summary();
+    }
 }
+
+/// Globs excluded by `--exclude-tests`: common test directories and test
+/// file naming conventions across ecosystems.
+pub const TEST_EXCLUDE_GLOBS: &[&str] = &[
+    "tests/**",
+    "test/**",
+    "spec/**",
+    "__tests__/**",
+    "**/tests/**",
+    "**/test/**",
+    "**/spec/**",
+    "**/__tests__/**",
+    "**/*_test.go",
+    "**/*_test.py",
+    "**/test_*.py",
+    "**/*_test.rb",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+];
 
 /// Parse a severity string (as used in `--fail-on` and config files).
 fn parse_severity(s: &str) -> Option<Severity> {
@@ -230,6 +279,7 @@ pub async fn run_all(path: &Path, scanners: &[&str], config: &Config) -> Result<
     }
 
     results.deduplicate();
+    results.apply_excludes(&config.exclude);
 
     Ok(results)
 }
@@ -522,6 +572,60 @@ mod tests {
         results.deduplicate();
         assert_eq!(results.findings.len(), 0);
         assert_eq!(results.summary.total, 0);
+    }
+
+    #[test]
+    fn test_apply_excludes_glob() {
+        let mut results = results_with(vec![
+            make_finding("a", "sast", Severity::High, "vendor/lib.py", Some(1)),
+            make_finding("b", "sast", Severity::High, "src/app.py", Some(2)),
+            make_finding("c", "sast", Severity::High, "./vendor/other.py", Some(3)),
+        ]);
+        results.apply_excludes(&["vendor/**".to_string()]);
+        assert_eq!(results.findings.len(), 1);
+        assert_eq!(results.findings[0].file, "src/app.py");
+        assert_eq!(results.summary.total, 1);
+    }
+
+    #[test]
+    fn test_apply_excludes_empty_patterns_is_noop() {
+        let mut results = results_with(vec![make_finding(
+            "a",
+            "sast",
+            Severity::High,
+            "vendor/lib.py",
+            Some(1),
+        )]);
+        results.apply_excludes(&[]);
+        assert_eq!(results.findings.len(), 1);
+    }
+
+    #[test]
+    fn test_apply_excludes_invalid_glob_ignored() {
+        let mut results = results_with(vec![make_finding(
+            "a",
+            "sast",
+            Severity::High,
+            "src/app.py",
+            Some(1),
+        )]);
+        results.apply_excludes(&["[bad".to_string()]);
+        assert_eq!(results.findings.len(), 1);
+    }
+
+    #[test]
+    fn test_exclude_tests_globs_match_common_layouts() {
+        let patterns: Vec<String> = TEST_EXCLUDE_GLOBS.iter().map(|s| s.to_string()).collect();
+        let mut results = results_with(vec![
+            make_finding("a", "sast", Severity::High, "tests/test_app.py", Some(1)),
+            make_finding("b", "sast", Severity::High, "src/__tests__/x.js", Some(2)),
+            make_finding("c", "sast", Severity::High, "pkg/handler_test.go", Some(3)),
+            make_finding("d", "sast", Severity::High, "src/Button.test.tsx", Some(4)),
+            make_finding("e", "sast", Severity::High, "src/app.py", Some(5)),
+        ]);
+        results.apply_excludes(&patterns);
+        assert_eq!(results.findings.len(), 1);
+        assert_eq!(results.findings[0].file, "src/app.py");
     }
 
     #[test]

--- a/src/scanners/sast.rs
+++ b/src/scanners/sast.rs
@@ -13,7 +13,7 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
 
     let mut cmd = Command::new("semgrep");
     cmd.arg("scan").arg("--json").arg("--quiet").arg(path);
-    build_semgrep_args(&mut cmd, config);
+    build_semgrep_args(&mut cmd, config, path);
 
     let output = cmd.output()?;
 
@@ -83,8 +83,43 @@ fn ai_generated_code_rules_path() -> std::io::Result<std::path::PathBuf> {
     Ok(dir)
 }
 
+/// True if the file looks like a semgrep rule file (YAML with a top-level
+/// `rules:` key). Used when auto-discovering a project's rules/ directory so
+/// unrelated YAML never breaks the scan.
+fn is_semgrep_rule_file(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    content
+        .lines()
+        .any(|line| line.trim_end() == "rules:" || line.starts_with("rules:"))
+}
+
+/// Discover custom semgrep rule files in `<scan-path>/rules/` (recursive).
+fn discover_custom_rules(scan_path: &Path) -> Vec<std::path::PathBuf> {
+    let rules_dir = scan_path.join("rules");
+    if !rules_dir.is_dir() {
+        return vec![];
+    }
+    let mut found: Vec<std::path::PathBuf> = walkdir::WalkDir::new(&rules_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().is_file()
+                && matches!(
+                    e.path().extension().and_then(|x| x.to_str()),
+                    Some("yml") | Some("yaml")
+                )
+                && is_semgrep_rule_file(e.path())
+        })
+        .map(|e| e.into_path())
+        .collect();
+    found.sort();
+    found
+}
+
 /// Build semgrep rule config and exclude arguments.
-fn build_semgrep_args(cmd: &mut Command, config: &Config) {
+fn build_semgrep_args(cmd: &mut Command, config: &Config, scan_path: &Path) {
     // Add rule configs; default to OWASP Top 10 if none specified
     let rules = &config.scanners.sast.rules;
     if rules.is_empty() {
@@ -111,6 +146,21 @@ fn build_semgrep_args(cmd: &mut Command, config: &Config) {
                 }
             }
         }
+    }
+
+    // Explicit custom rule files/dirs from .shipsafe.yml
+    for rules_path in &config.scanners.sast.rules_paths {
+        cmd.arg("--config").arg(rules_path);
+    }
+
+    // Auto-discovered rules from the project's rules/ directory
+    for rule_file in discover_custom_rules(scan_path) {
+        cmd.arg("--config").arg(rule_file);
+    }
+
+    // Disabled rule IDs
+    for rule_id in &config.scanners.sast.disabled_rules {
+        cmd.arg("--exclude-rule").arg(rule_id);
     }
 
     // Add excludes
@@ -387,7 +437,7 @@ mod tests {
         config.scanners.sast.exclude = vec![];
 
         let mut cmd = Command::new("semgrep");
-        build_semgrep_args(&mut cmd, &config);
+        build_semgrep_args(&mut cmd, &config, Path::new("."));
 
         let args = get_args(&cmd);
         assert!(args.contains(&"--config".to_string()));
@@ -401,13 +451,56 @@ mod tests {
         config.scanners.sast.exclude = vec!["vendor".into()];
 
         let mut cmd = Command::new("semgrep");
-        build_semgrep_args(&mut cmd, &config);
+        build_semgrep_args(&mut cmd, &config, Path::new("."));
 
         let args = get_args(&cmd);
         assert!(args.contains(&"p/owasp-top-ten".to_string()));
         assert!(args.iter().any(|a| a.ends_with("ai-generated-rules")));
         assert!(args.contains(&"--exclude".to_string()));
         assert!(args.contains(&"vendor".to_string()));
+    }
+
+    #[test]
+    fn test_rules_paths_and_disabled_rules_args() {
+        let mut config = Config::default();
+        config.scanners.sast.rules_paths = vec!["./my-rules/".into()];
+        config.scanners.sast.disabled_rules = vec!["ai-rust-unsafe-block".into()];
+
+        let mut cmd = Command::new("semgrep");
+        build_semgrep_args(&mut cmd, &config, Path::new("."));
+
+        let args = get_args(&cmd);
+        assert!(args.contains(&"./my-rules/".to_string()));
+        assert!(args.contains(&"--exclude-rule".to_string()));
+        assert!(args.contains(&"ai-rust-unsafe-block".to_string()));
+    }
+
+    #[test]
+    fn test_discover_custom_rules() {
+        let dir =
+            std::env::temp_dir().join(format!("shipsafe-discover-test-{}", std::process::id()));
+        let rules_dir = dir.join("rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        std::fs::write(
+            rules_dir.join("custom.yml"),
+            "rules:\n  - id: x\n    pattern: foo\n    message: m\n    languages: [python]\n    severity: ERROR\n",
+        )
+        .unwrap();
+        // Non-rule YAML must be ignored.
+        std::fs::write(rules_dir.join("docker-compose.yml"), "services: {}\n").unwrap();
+        // Non-YAML files must be ignored.
+        std::fs::write(rules_dir.join("README.md"), "rules:\n").unwrap();
+
+        let found = discover_custom_rules(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("custom.yml"));
+    }
+
+    #[test]
+    fn test_discover_custom_rules_no_dir() {
+        assert!(discover_custom_rules(Path::new("/nonexistent-shipsafe")).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **#22 カスタムルール読み込み**: プロジェクトの `rules/` ディレクトリを自動スキャン(トップレベル `rules:` キーを持つ YAML のみ)。`scanners.sast.rules-paths` で明示パス指定、`disabled-rules` で ID 単位の無効化 (semgrep `--exclude-rule`)。
- **#23 Exclude/Allow 強化**: トップレベル `exclude` glob を全スキャナーの findings に一律適用。`--exclude-tests` でテストディレクトリ/ファイルの定番 glob を一括除外。
- **#24 設定バリデーション**: `shipsafe validate` コマンド。未知キーの指摘(候補提示)、enum 値チェック、regex/glob のコンパイル検証、rules-paths の存在チェック。ja/en 対応。

## Test plan
- `cargo test` 67 tests green / clippy / fmt
- 手動: 不正 config で `validate` が問題を列挙し exit 1、正常 config で ✔ exit 0 を確認

Closes #22
Closes #23
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)