### PR TITLE
Error handling: graceful degradation, scan timeouts, network retries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,12 +28,25 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct ScannersConfig {
     pub sast: SastConfig,
     pub sca: ScaConfig,
     pub secrets: SecretsConfig,
+    /// Per-scanner timeout in seconds; a scanner exceeding it is skipped.
+    #[serde(alias = "timeout_seconds")]
+    pub timeout_seconds: u64,
+}
+impl Default for ScannersConfig {
+    fn default() -> Self {
+        Self {
+            sast: SastConfig::default(),
+            sca: ScaConfig::default(),
+            secrets: SecretsConfig::default(),
+            timeout_seconds: 300,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,7 +156,16 @@ pub fn init_config() -> Result<()> {
 /// Known config keys per section, accepting both kebab-case and snake_case.
 const KNOWN_KEYS: &[(&str, &[&str])] = &[
     ("", &["version", "scanners", "output", "ai", "exclude"]),
-    ("scanners", &["sast", "sca", "secrets"]),
+    (
+        "scanners",
+        &[
+            "sast",
+            "sca",
+            "secrets",
+            "timeout-seconds",
+            "timeout_seconds",
+        ],
+    ),
     (
         "scanners.sast",
         &[
@@ -269,6 +291,10 @@ pub fn validate_file(path: &Path) -> Result<Vec<String>> {
             config.scanners.sca.fail_on_severity,
             SEVERITIES.join(", ")
         ));
+    }
+
+    if config.scanners.timeout_seconds == 0 {
+        errors.push("scanners.timeout-seconds: must be greater than 0".to_string());
     }
 
     for pattern in &config.scanners.secrets.allow_patterns {

--- a/src/scanners/exec.rs
+++ b/src/scanners/exec.rs
@@ -1,0 +1,192 @@
+//! Shared subprocess execution for scanners: async spawning, scan timeouts,
+//! and retry on transient network failures.
+
+use anyhow::{Context, Result};
+use std::process::Output;
+use std::time::Duration;
+
+/// Maximum number of attempts when a scanner fails with a network-looking
+/// error (1 initial try + 2 retries).
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Print a localized warning to stderr (visible to users, unlike tracing).
+pub fn warn_user(lang: &str, en: &str, ja: &str) {
+    if lang == "ja" {
+        eprintln!("  ⚠ {}", ja);
+    } else {
+        eprintln!("  ⚠ {}", en);
+    }
+}
+
+/// Heuristic: does this scanner output look like a transient network error
+/// worth retrying (registry fetch failures, DNS, TLS, rate limits)?
+pub fn is_network_error(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    [
+        "connection refused",
+        "connection reset",
+        "connection error",
+        "timed out",
+        "timeout",
+        "network",
+        "could not resolve",
+        "name resolution",
+        "dns",
+        "tls handshake",
+        "certificate",
+        "rate limit",
+        "too many requests",
+        "temporary failure",
+        "503 service",
+        "502 bad gateway",
+        "unable to download",
+        "failed to download",
+    ]
+    .iter()
+    .any(|kw| s.contains(kw))
+}
+
+/// Run a scanner command with a timeout and network-error retries.
+///
+/// `build` is called per attempt because a tokio Command cannot be reused
+/// after spawning. Returns `Ok(None)` when the scan timed out (a warning is
+/// printed and the scanner is skipped) so a single slow tool never hangs the
+/// whole gate.
+pub async fn run_scanner(
+    tool: &str,
+    build: impl Fn() -> tokio::process::Command,
+    timeout_seconds: u64,
+    lang: &str,
+) -> Result<Option<Output>> {
+    let mut last_output: Option<Output> = None;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let mut cmd = build();
+        cmd.kill_on_drop(true);
+
+        let result = tokio::time::timeout(Duration::from_secs(timeout_seconds), cmd.output()).await;
+
+        let output = match result {
+            Err(_elapsed) => {
+                warn_user(
+                    lang,
+                    &format!(
+                        "{} timed out after {}s — skipping (set scanners.timeout-seconds in .shipsafe.yml to adjust)",
+                        tool, timeout_seconds
+                    ),
+                    &format!(
+                        "{} が {} 秒でタイムアウトしました — スキップします (.shipsafe.yml の scanners.timeout-seconds で調整できます)",
+                        tool, timeout_seconds
+                    ),
+                );
+                return Ok(None);
+            }
+            Ok(spawned) => spawned.with_context(|| format!("failed to run {}", tool))?,
+        };
+
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if !output.status.success() && is_network_error(&stderr) && attempt < MAX_ATTEMPTS {
+            warn_user(
+                lang,
+                &format!(
+                    "{} hit a network error (attempt {}/{}), retrying...",
+                    tool, attempt, MAX_ATTEMPTS
+                ),
+                &format!(
+                    "{} でネットワークエラーが発生しました (試行 {}/{})。リトライします...",
+                    tool, attempt, MAX_ATTEMPTS
+                ),
+            );
+            tokio::time::sleep(Duration::from_millis(500 * u64::from(attempt))).await;
+            last_output = Some(output);
+            continue;
+        }
+
+        return Ok(Some(output));
+    }
+
+    Ok(last_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_network_error_positive() {
+        assert!(is_network_error("error: connection refused by host"));
+        assert!(is_network_error("Request Timed Out while fetching rules"));
+        assert!(is_network_error("TLS handshake failure"));
+        assert!(is_network_error("could not resolve registry.example.com"));
+        assert!(is_network_error("429 Too Many Requests"));
+        assert!(is_network_error("failed to download vulnerability DB"));
+    }
+
+    #[test]
+    fn test_is_network_error_negative() {
+        assert!(!is_network_error("syntax error in rule file"));
+        assert!(!is_network_error("no such file or directory"));
+        assert!(!is_network_error(""));
+    }
+
+    #[tokio::test]
+    async fn test_run_scanner_success() {
+        let out = run_scanner(
+            "echo",
+            || {
+                let mut c = tokio::process::Command::new("echo");
+                c.arg("hello");
+                c
+            },
+            10,
+            "en",
+        )
+        .await
+        .unwrap()
+        .expect("should complete");
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    #[tokio::test]
+    async fn test_run_scanner_timeout_returns_none() {
+        let out = run_scanner(
+            "sleep",
+            || {
+                let mut c = tokio::process::Command::new("sleep");
+                c.arg("5");
+                c
+            },
+            1,
+            "en",
+        )
+        .await
+        .unwrap();
+        assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_run_scanner_missing_binary_is_error() {
+        let res = run_scanner(
+            "definitely-not-a-real-binary",
+            || tokio::process::Command::new("definitely-not-a-real-binary-shipsafe"),
+            5,
+            "en",
+        )
+        .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_scanner_non_network_failure_no_retry() {
+        // `false` exits 1 with no stderr; must return after one attempt
+        // (a retry loop would still return, but quickly check output passes
+        // through).
+        let out = run_scanner("false", || tokio::process::Command::new("false"), 5, "en")
+            .await
+            .unwrap()
+            .expect("should complete");
+        assert!(!out.status.success());
+    }
+}

--- a/src/scanners/mod.rs
+++ b/src/scanners/mod.rs
@@ -1,3 +1,4 @@
+pub mod exec;
 pub mod sast;
 pub mod sca;
 pub mod secrets;

--- a/src/scanners/sast.rs
+++ b/src/scanners/sast.rs
@@ -1,21 +1,37 @@
 use crate::config::Config;
+use crate::scanners::exec;
 use crate::scanners::{Finding, ScanResults, Severity};
 use anyhow::Result;
 use std::path::Path;
-use std::process::Command;
+use tokio::process::Command;
 
 pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
     // Check if semgrep is available
     if which::which("semgrep").is_err() {
-        tracing::warn!("semgrep not found, skipping SAST scan");
+        exec::warn_user(
+            &config.lang,
+            "semgrep not found — SAST scan skipped. Run 'shipsafe doctor' for install instructions.",
+            "semgrep が見つかりません — SAST スキャンをスキップしました。'shipsafe doctor' でインストール方法を確認できます。",
+        );
         return Ok(ScanResults::new());
     }
 
-    let mut cmd = Command::new("semgrep");
-    cmd.arg("scan").arg("--json").arg("--quiet").arg(path);
-    build_semgrep_args(&mut cmd, config, path);
+    let output = exec::run_scanner(
+        "semgrep",
+        || {
+            let mut cmd = Command::new("semgrep");
+            cmd.arg("scan").arg("--json").arg("--quiet").arg(path);
+            build_semgrep_args(&mut cmd, config, path);
+            cmd
+        },
+        config.scanners.timeout_seconds,
+        &config.lang,
+    )
+    .await?;
 
-    let output = cmd.output()?;
+    let Some(output) = output else {
+        return Ok(ScanResults::new());
+    };
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stderr.is_empty() {
@@ -23,10 +39,11 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
     }
 
     if !output.status.success() {
-        tracing::warn!(
-            "semgrep exited with status {}: {}",
-            output.status,
-            stderr.lines().next().unwrap_or("(no details)")
+        let first = stderr.lines().next().unwrap_or("(no details)");
+        exec::warn_user(
+            &config.lang,
+            &format!("semgrep exited with {}: {}", output.status, first),
+            &format!("semgrep が異常終了しました ({}): {}", output.status, first),
         );
     }
 
@@ -425,7 +442,8 @@ mod tests {
 
     /// Helper to extract args from a Command for testing.
     fn get_args(cmd: &Command) -> Vec<String> {
-        cmd.get_args()
+        cmd.as_std()
+            .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect()
     }

--- a/src/scanners/sca.rs
+++ b/src/scanners/sca.rs
@@ -1,8 +1,9 @@
 use crate::config::Config;
+use crate::scanners::exec;
 use crate::scanners::{Finding, ScanResults, Severity};
 use anyhow::Result;
 use std::path::Path;
-use std::process::Command;
+use tokio::process::Command;
 
 /// Detect package managers present in the target directory by checking for
 /// lock files and manifest files commonly scanned by trivy/grype.
@@ -49,22 +50,38 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
         tracing::info!("trivy not found, falling back to grype");
         results = run_grype(path, config).await?;
     } else {
-        tracing::warn!("Neither trivy nor grype found, skipping SCA scan");
+        exec::warn_user(
+            &config.lang,
+            "neither trivy nor grype found — SCA scan skipped. Run 'shipsafe doctor' for install instructions.",
+            "trivy / grype が見つかりません — SCA スキャンをスキップしました。'shipsafe doctor' でインストール方法を確認できます。",
+        );
     }
 
     Ok(results)
 }
 
-async fn run_trivy(path: &Path, _config: &Config) -> Result<ScanResults> {
-    let output = Command::new("trivy")
-        .arg("fs")
-        .arg("--format")
-        .arg("json")
-        .arg("--quiet")
-        .arg("--scanners")
-        .arg("vuln")
-        .arg(path)
-        .output()?;
+async fn run_trivy(path: &Path, config: &Config) -> Result<ScanResults> {
+    let output = exec::run_scanner(
+        "trivy",
+        || {
+            let mut cmd = Command::new("trivy");
+            cmd.arg("fs")
+                .arg("--format")
+                .arg("json")
+                .arg("--quiet")
+                .arg("--scanners")
+                .arg("vuln")
+                .arg(path);
+            cmd
+        },
+        config.scanners.timeout_seconds,
+        &config.lang,
+    )
+    .await?;
+
+    let Some(output) = output else {
+        return Ok(ScanResults::new());
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -142,13 +159,25 @@ fn parse_trivy_json(json_str: &str) -> ScanResults {
     results
 }
 
-async fn run_grype(path: &Path, _config: &Config) -> Result<ScanResults> {
-    let output = Command::new("grype")
-        .arg(format!("dir:{}", path.display()))
-        .arg("-o")
-        .arg("json")
-        .arg("--quiet")
-        .output()?;
+async fn run_grype(path: &Path, config: &Config) -> Result<ScanResults> {
+    let output = exec::run_scanner(
+        "grype",
+        || {
+            let mut cmd = Command::new("grype");
+            cmd.arg(format!("dir:{}", path.display()))
+                .arg("-o")
+                .arg("json")
+                .arg("--quiet");
+            cmd
+        },
+        config.scanners.timeout_seconds,
+        &config.lang,
+    )
+    .await?;
+
+    let Some(output) = output else {
+        return Ok(ScanResults::new());
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/scanners/secrets.rs
+++ b/src/scanners/secrets.rs
@@ -1,9 +1,10 @@
 use crate::config::Config;
+use crate::scanners::exec;
 use crate::scanners::{Finding, ScanResults, Severity};
 use anyhow::Result;
 use regex::Regex;
 use std::path::Path;
-use std::process::Command;
+use tokio::process::Command;
 
 /// Bundled gitleaks extension config with Japanese cloud / SaaS credential
 /// patterns (Sakura Cloud, LINE, PayPay, freee, kintone). Extends the
@@ -219,7 +220,11 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
     let mut results = ScanResults::new();
 
     if which::which("gitleaks").is_err() {
-        tracing::warn!("gitleaks not found, skipping secrets scan");
+        exec::warn_user(
+            &config.lang,
+            "gitleaks not found — secrets scan skipped. Run 'shipsafe doctor' for install instructions.",
+            "gitleaks が見つかりません — シークレットスキャンをスキップしました。'shipsafe doctor' でインストール方法を確認できます。",
+        );
         return Ok(results);
     }
 
@@ -249,37 +254,51 @@ pub async fn run(path: &Path, config: &Config) -> Result<ScanResults> {
             .unwrap_or(0)
     ));
 
-    let mut cmd = Command::new("gitleaks");
-    cmd.arg("detect")
-        .arg("--source")
-        .arg(path)
-        .arg("--report-format")
-        .arg("json")
-        .arg("--report-path")
-        .arg(&report_path)
-        .arg("--no-banner");
-
     // Extend the default ruleset with bundled Japanese cloud/SaaS patterns.
-    match gitleaks_config_path() {
-        Ok(config_path) => {
-            cmd.arg("--config").arg(config_path);
-        }
+    let gitleaks_config = match gitleaks_config_path() {
+        Ok(config_path) => Some(config_path),
         Err(e) => {
             tracing::warn!(
                 "failed to materialize bundled gitleaks config, using defaults: {}",
                 e
             );
+            None
         }
-    }
+    };
 
-    // Enable git history scanning
-    if config.scanners.secrets.scan_history {
-        cmd.arg("--log-opts").arg("--all");
-    } else {
-        cmd.arg("--no-git");
-    }
+    let output = exec::run_scanner(
+        "gitleaks",
+        || {
+            let mut cmd = Command::new("gitleaks");
+            cmd.arg("detect")
+                .arg("--source")
+                .arg(path)
+                .arg("--report-format")
+                .arg("json")
+                .arg("--report-path")
+                .arg(&report_path)
+                .arg("--no-banner");
 
-    let output = cmd.output()?;
+            if let Some(ref config_path) = gitleaks_config {
+                cmd.arg("--config").arg(config_path);
+            }
+
+            // Enable git history scanning
+            if config.scanners.secrets.scan_history {
+                cmd.arg("--log-opts").arg("--all");
+            } else {
+                cmd.arg("--no-git");
+            }
+            cmd
+        },
+        config.scanners.timeout_seconds,
+        &config.lang,
+    )
+    .await?;
+
+    let Some(output) = output else {
+        return Ok(results);
+    };
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stderr.is_empty() {


### PR DESCRIPTION
## Summary
- **#27 エラーハンドリング強化**:
  - `scanners::exec` モジュール新設。全スキャナーの実行を tokio 非同期サブプロセスに統一 (従来は tokio future 内で blocking `std::process` を呼んでいたため実質逐次実行だった — 真の並列実行になり #26 にも寄与)
  - `scanners.timeout-seconds` 設定 (デフォルト 300 秒)。超過したスキャナーは kill してスキップ + 日本語/英語の警告
  - ネットワーク系エラー (registry fetch / DNS / TLS / rate limit) は backoff 付きで最大 2 回リトライ
  - スキャナー未インストール時は 'shipsafe doctor' を案内する可視の警告 (従来は tracing ログのみ)
  - スキャナー異常終了時は stderr 先頭行を含む簡潔なエラーを表示

## Test plan
- `cargo test` 77 tests green (timeout / リトライ判定 / 欠落バイナリのユニットテスト追加)
- 手動: PATH からスキャナーを外して 3 種の警告表示と exit 0 (graceful skip) を確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)