### PR TITLE
Release infrastructure: multi-platform binaries, Docker, Homebrew, crates.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.git/
+.github/
+fixtures/
+docs/
+site/
+tests/
+*.md
+.claude/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,154 @@ on:
 
 permissions:
   contents: write
+  packages: write
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar -czf "$GITHUB_WORKSPACE/shipsafe-${{ matrix.target }}.tar.gz" shipsafe
+          cd "$GITHUB_WORKSPACE"
+          shasum -a 256 "shipsafe-${{ matrix.target }}.tar.gz" > "shipsafe-${{ matrix.target }}.tar.gz.sha256"
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/shipsafe.exe" -DestinationPath "shipsafe-${{ matrix.target }}.zip"
+          $hash = (Get-FileHash "shipsafe-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  shipsafe-${{ matrix.target }}.zip" | Out-File -Encoding ascii "shipsafe-${{ matrix.target }}.zip.sha256"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: shipsafe-${{ matrix.target }}.*
+
   release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+      - name: Combined checksums
+        run: cat *.sha256 > SHA256SUMS
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            shipsafe-*.tar.gz
+            shipsafe-*.tar.gz.sha256
+            shipsafe-*.zip
+            shipsafe-*.zip.sha256
+            SHA256SUMS
+          generate_release_notes: true
+
+  docker:
+    name: Push Docker image to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/baneido/shipsafe
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  crates:
+    name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build release
-        run: cargo build --release
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: target/release/shipsafe
-          generate_release_notes: true
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "::warning::CARGO_REGISTRY_TOKEN not set — skipping crates.io publish"
+            exit 0
+          fi
+          cargo publish --locked
+
+  homebrew:
+    name: Update Homebrew formula
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update baneido/homebrew-tap
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::warning::TAP_GITHUB_TOKEN not set — skipping Homebrew formula update"
+            exit 0
+          fi
+          VERSION="${TAG#v}"
+          URL="https://github.com/baneido/shipsafe/archive/refs/tags/${TAG}.tar.gz"
+          curl -fsSL "$URL" -o source.tar.gz
+          SHA=$(sha256sum source.tar.gz | awk '{print $1}')
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/baneido/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          sed -e "s|{{VERSION}}|${VERSION}|g" \
+              -e "s|{{URL}}|${URL}|g" \
+              -e "s|{{SHA256}}|${SHA}|g" \
+              scripts/shipsafe.rb.tmpl > tap/Formula/shipsafe.rb
+          cd tap
+          git config user.name "shipsafe-release-bot"
+          git config user.email "contact@baneido.com"
+          git add Formula/shipsafe.rb
+          git commit -m "shipsafe ${VERSION}" || echo "no changes"
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,38 @@
-FROM rust:1.75-slim AS builder
+# --- Build stage -----------------------------------------------------------
+FROM rust:1-slim AS builder
 WORKDIR /app
-COPY . .
-RUN cargo build --release
 
+# Cache the dependency graph: build a dummy main against the real manifests
+# so source edits don't invalidate the dependency layer.
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src \
+    && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
+
+COPY . .
+RUN touch src/main.rs && cargo build --release && strip target/release/shipsafe
+
+# --- Runtime stage ----------------------------------------------------------
 FROM debian:bookworm-slim
+
+LABEL org.opencontainers.image.title="ShipSafe" \
+      org.opencontainers.image.description="AI-Powered Pre-Deploy Security Gate" \
+      org.opencontainers.image.source="https://github.com/baneido/shipsafe" \
+      org.opencontainers.image.licenses="MIT"
+
+ARG TRIVY_VERSION=v0.58.1
+ARG GITLEAKS_VERSION=8.30.1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip ca-certificates curl git \
-    && pip3 install semgrep --break-system-packages \
-    && curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
-    && curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64 -o /usr/local/bin/gitleaks \
-    && chmod +x /usr/local/bin/gitleaks \
-    && rm -rf /var/lib/apt/lists/*
+    && pip3 install --no-cache-dir --break-system-packages semgrep \
+    && curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+       | sh -s -- -b /usr/local/bin ${TRIVY_VERSION} \
+    && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+       | tar -xz -C /usr/local/bin gitleaks \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/* /root/.cache
 
 COPY --from=builder /app/target/release/shipsafe /usr/local/bin/shipsafe
 

--- a/scripts/shipsafe.rb.tmpl
+++ b/scripts/shipsafe.rb.tmpl
@@ -1,0 +1,30 @@
+# Template for the Homebrew formula published to baneido/homebrew-tap.
+# Placeholders ({{VERSION}}, {{URL}}, {{SHA256}}) are filled by the release
+# workflow's homebrew job.
+class Shipsafe < Formula
+  desc "AI-Powered Pre-Deploy Security Gate - SAST, SCA, and secrets scanning"
+  homepage "https://github.com/baneido/shipsafe"
+  url "{{URL}}"
+  sha256 "{{SHA256}}"
+  version "{{VERSION}}"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  def caveats
+    <<~EOS
+      ShipSafe orchestrates external scanners. Install them with:
+        brew install semgrep trivy gitleaks
+      Verify with:
+        shipsafe doctor
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/shipsafe version")
+  end
+end


### PR DESCRIPTION
## Summary
- **#32 リリースバイナリ自動ビルド**: 5 ターゲット (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64) のビルドマトリクス。tar.gz/zip + 各 .sha256 + 結合 SHA256SUMS を GitHub Release に自動アップロード。アセット名は `scripts/install.sh` の期待と一致。
- **#17 Docker イメージ公開**: リリース時に ghcr.io/baneido/shipsafe へ {version} / {major}.{minor} / latest を自動プッシュ (buildx + GHA キャッシュ)。Dockerfile を最適化: 依存レイヤキャッシュ、strip、trivy/gitleaks のバージョンピン、pip --no-cache-dir、OCI ラベル、.dockerignore。
- **#18 Homebrew Formula**: [baneido/homebrew-tap](https://github.com/baneido/homebrew-tap) を作成し初期 Formula を配置済み。リリース時に `scripts/shipsafe.rb.tmpl` から自動更新 (TAP_GITHUB_TOKEN 未設定時は警告スキップ)。
- **#48 crates.io 公開**: リリースワークフローに cargo publish ジョブ (CARGO_REGISTRY_TOKEN 未設定時は警告スキップ)。インストールスクリプト本体は #56 で導入済み。

## Secrets 設定が必要 (リリース前)
- `CARGO_REGISTRY_TOKEN` — crates.io publish 用
- `TAP_GITHUB_TOKEN` — homebrew-tap 更新用 (repo スコープ PAT)

## Test plan
- release.yml は YAML 検証済み。v0.1.0 タグ (#34) で実走
- Dockerfile はローカル docker 不在のため リリース時の CI で検証

Closes #17
Closes #18
Closes #32
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)