### PR TITLE
Landing page, launch materials, and Marketplace guide

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy landing page to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/launch/marketplace.md
+++ b/docs/launch/marketplace.md
@@ -1,0 +1,43 @@
+# GitHub Actions Marketplace 公開手順 (#15)
+
+action.yml はリポジトリルートにあり、Marketplace 公開要件 (root action /
+`name` / `description` / `branding`) を満たしています。
+
+- name: **ShipSafe Security Scan**
+- branding: shield / red
+- カテゴリ: **Security** (primary), **Code quality** (secondary)
+
+## 公開手順 (リリース時の手動ステップ)
+
+Marketplace への掲載はリリース UI のチェックボックスでのみ行えます
+(API 非対応)。v0.1.0 リリース時に:
+
+1. https://github.com/baneido/shipsafe/releases で v0.1.0 リリースを開き
+   **Edit** する
+2. **Publish this Action to the GitHub Marketplace** にチェック
+   - 初回は Marketplace Developer Agreement への同意と 2FA が必要
+3. Primary category: **Security** / Another category: **Code quality**
+4. **Update release** で公開
+
+公開後、`uses: baneido/shipsafe@v1` 用に major タグを维持する:
+
+```sh
+git tag -f v1 v0.1.0 && git push -f origin v1
+```
+
+(以後のパッチリリースごとに v1 を進める)
+
+## README スクリーンショット
+
+Marketplace 掲載ページは README を表示する。以下を撮影して
+`docs/images/` に追加し README から参照する (任意だが推奨):
+
+- [ ] PR サマリーコメント + インラインコメント
+- [ ] Security タブの ShipSafe アラート
+- [ ] ターミナルのスキャン出力 (ja)
+
+## サンプルワークフロー
+
+README の [GitHub Actions セクション](../../README.md#github-actions) と
+self-scan 実例 [.github/workflows/shipsafe.yml](../../.github/workflows/shipsafe.yml)
+がそのままサンプルとして機能する。

--- a/docs/launch/product-hunt.md
+++ b/docs/launch/product-hunt.md
@@ -1,0 +1,59 @@
+# Product Hunt launch draft
+
+## Listing
+
+- **Name:** ShipSafe
+- **Tagline (60 chars):** One-command security gate for AI-generated code
+- **Topics:** Developer Tools, GitHub, Open Source, Security
+- **Links:** https://github.com/baneido/shipsafe · https://shipsafe.dev
+
+## Description
+
+ShipSafe is an open-source pre-deploy security gate that runs SAST
+(semgrep), dependency scanning (trivy), and secret detection (gitleaks) in
+parallel with a single command — and turns the merged result into one exit
+code your CI can trust.
+
+What makes it different:
+
+🤖 **Rules for AI-generated code.** Copilot/Cursor/ChatGPT keep producing
+the same vulnerable patterns: string-concatenated SQL, missing auth
+middleware, `dangerouslySetInnerHTML`, swallowed Go errors, `unsafe` Rust.
+ShipSafe ships a semgrep rule pack targeting exactly those, for Python,
+JS/TS, Rust, and Go.
+
+⚡ **Fast.** Scanners run as parallel async subprocesses; a 100k-line repo
+scans in ~6 seconds.
+
+💬 **One line in GitHub Actions.** `uses: baneido/shipsafe@v1` gets you PR
+summary + inline comments, the Security tab (SARIF), and build gating.
+
+🇯🇵 **Japanese-native.** Full Japanese output, plus secret detection for
+Japanese cloud services (Sakura Cloud, LINE, PayPay, freee, kintone) that
+global tools miss.
+
+Free and MIT-licensed. We'd love your feedback!
+
+## First comment (maker)
+
+Hi Product Hunt! 👋
+
+We built ShipSafe after watching teams ship AI-generated code faster than
+they could review it. Existing scanners are great but fragmented — three
+tools, three configs, three result formats, and a wall of noise.
+
+ShipSafe is our answer: one command, one config, one severity model, one
+exit code. The fun part: while building it, ShipSafe's own gate caught a
+shell-injection pattern in our GitHub Action and a missing non-root USER
+in our Dockerfile. Dogfooding works 😅
+
+Ask us anything — and tell us which AI-generated vulnerability patterns
+you keep seeing; we're growing the rule pack.
+
+## Gallery / screenshots checklist
+
+- [ ] Terminal: full scan with findings (ja and en)
+- [ ] PR summary comment + inline comment screenshot
+- [ ] GitHub Security tab with ShipSafe SARIF alerts
+- [ ] `shipsafe doctor` output
+- [ ] Landing page hero

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,42 @@
+# Show HN draft
+
+**Title:** Show HN: ShipSafe – one-command security gate tuned for AI-generated code (Rust)
+
+**URL:** https://github.com/baneido/shipsafe
+
+**Text:**
+
+Hi HN — we built ShipSafe, an open-source CLI that runs semgrep (SAST),
+trivy (dependencies), and gitleaks (secrets) in parallel and merges
+everything into one deduplicated report and one exit code.
+
+Why another wrapper? Three reasons:
+
+1. *AI-generated code has a signature.* Reviewing LLM-written PRs, we kept
+   seeing the same classes of bugs: f-string SQL, routes without auth
+   middleware, `dangerouslySetInnerHTML`, `yaml.load`, `static mut`,
+   `if err != nil {}`. We wrote a semgrep rule pack for those patterns
+   (Python/JS/TS/Rust/Go), with `semgrep --test` cases for every rule.
+
+2. *Gates should be boring.* One severity model across tools, a
+   `--fail-on` threshold, per-scanner timeouts, retry-on-network-flake,
+   and graceful degradation when a scanner isn't installed. A 100k-line
+   polyglot repo scans in ~6s because the scanners genuinely run
+   concurrently (tokio + async subprocesses).
+
+3. *Non-US coverage.* Most secret scanners know AWS and Stripe but not
+   the providers common in Japan. ShipSafe bundles gitleaks rules for
+   Sakura Cloud, LINE, PayPay, freee, and kintone, and the whole CLI
+   speaks Japanese (`--lang ja`).
+
+Favorite dogfooding moment: our own gate failed our PR because the GitHub
+Action passed `${{ inputs.* }}` straight into `run:` (shell injection) and
+the Dockerfile lacked a non-root USER. Both fixed before merge.
+
+It's Rust, MIT-licensed. GitHub Action: `uses: baneido/shipsafe@v1` gives
+PR comments + Security-tab SARIF. Honest limitations: the "AI triage /
+fix suggestions" you may expect from the name are roadmap (v0.2), not
+shipped — v0.1 is the deterministic gate.
+
+Would love feedback, especially on the rule pack's false-positive rate on
+your codebases.

--- a/docs/launch/x-announcement.md
+++ b/docs/launch/x-announcement.md
@@ -1,0 +1,59 @@
+# X (Twitter) 告知ドラフト
+
+## 日本語メインツイート
+
+🛡️ ShipSafe v0.1.0 をリリースしました
+
+デプロイ前のセキュリティチェックをワンコマンドに:
+✅ SAST + 依存関係 + シークレット検出を並列実行
+🤖 AI が生成しがちな脆弱コードの検出ルール同梱
+🇯🇵 さくら/LINE/PayPay/freee/kintone のキー検出
+⚡ 10万行を約6秒でスキャン
+
+OSS (MIT) です👇
+https://github.com/baneido/shipsafe
+
+## スレッド (2/4)
+
+GitHub Actions なら 1 行で導入できます。
+
+PR にサマリー+変更行へのインラインコメント、
+Security タブに SARIF 連携、しきい値でビルド制御。
+
+```yaml
+- uses: baneido/shipsafe@v1
+  with:
+    fail-on: high
+    lang: ja
+```
+
+## スレッド (3/4)
+
+おもしろかったのは、開発中に ShipSafe 自身のゲートが
+自分のリポジトリの問題を 2 つ検出したこと。
+
+- GitHub Action の shell injection パターン
+- Dockerfile の非 root USER 欠落
+
+ドッグフーディング大事 😅
+
+## スレッド (4/4)
+
+v0.1 は「決定的なゲート」に集中しています。
+AI トリアージ / AI 修正提案は v0.2 のロードマップ。
+
+フィードバック・誤検知報告お待ちしています!
+⭐ もらえると励みになります
+https://github.com/baneido/shipsafe
+
+## English tweet
+
+🛡️ ShipSafe v0.1.0 is out — an open-source, one-command pre-deploy
+security gate.
+
+✅ SAST + SCA + secrets, run in parallel (~6s for 100k lines)
+🤖 semgrep rules tuned for AI-generated code (py/js/ts/rust/go)
+💬 1-line GitHub Action: PR comments + Security tab
+🇯🇵 Japanese cloud secrets support
+
+MIT licensed → https://github.com/baneido/shipsafe

--- a/docs/launch/zenn-article.md
+++ b/docs/launch/zenn-article.md
@@ -1,0 +1,119 @@
+---
+title: "AI生成コード時代のセキュリティゲート「ShipSafe」を OSS で公開しました"
+emoji: "🛡️"
+type: "tech"
+topics: ["security", "rust", "githubactions", "semgrep", "oss"]
+published: false
+---
+
+# AI がコードを書く時代、レビューは追いつかない
+
+Copilot や Cursor、Claude にコードを書かせるのが当たり前になりました。生産性は確実に上がった一方で、こんな経験はないでしょうか。
+
+- LLM が書いた SQL が **f-string 結合** だった
+- 生成された Flask の管理画面ルートに **認証デコレータがなかった**
+- React コンポーネントに `dangerouslySetInnerHTML` がしれっと入っていた
+- Go のエラーハンドリングが `if err != nil {}` (空) だった
+
+どれも既存の静的解析で「原理的には」見つかります。しかし現実には SAST・SCA・シークレット検出と 3 種類のツールを別々に設定し、別々のフォーマットの結果を読む必要があり、ノイズに埋もれて誰も見なくなる——というのが多くの現場ではないでしょうか。
+
+そこで、**デプロイ前チェックをワンコマンドに統合するゲート** を Rust で書き、OSS として公開しました。
+
+https://github.com/baneido/shipsafe
+
+# ShipSafe とは
+
+```
+$ shipsafe scan --lang ja --fail-on high
+
+  ShipSafe v0.1.0 — Pre-Deploy Security Gate
+
+  ▶ SAST       ... 検出 2 件 (重大 1 件, 中 1 件)
+  ▶ SCA        ... 検出 1 件 (高 1 件)
+  ▶ Secrets    ... 検出 1 件 (高 1 件)
+
+!! 重大  ai-py-sql-injection-concat
+   場所: app.py:17
+   SQL クエリの文字列結合。パラメータ化クエリを使ってください。
+
+====================================================
+集計: 検出 4 件 | 重大 1 | 高 2 | 中 1 | 低 0
+
+✘ ビルド失敗: 重要度しきい値 (--fail-on high) 以上の検出が 3 件あります
+```
+
+中身は実績あるスキャナーのオーケストレーションです。
+
+| レイヤ | エンジン | 役割 |
+|---|---|---|
+| SAST | semgrep | コードの脆弱パターン検出 |
+| SCA | trivy (grype フォールバック) | 依存関係の CVE |
+| Secrets | gitleaks | 認証情報の混入 |
+
+3 つを **tokio の非同期サブプロセスとして並列実行** し、結果を単一の severity モデルに正規化、`(ルールID, ファイル, 行)` で重複排除して 1 つのレポートと 1 つの exit code にまとめます。手元の計測では **10 万行のリポジトリで約 6 秒** です ([ベンチマーク](https://github.com/baneido/shipsafe/blob/main/docs/benchmarks.md))。
+
+# 特徴 1: AI 生成コード検出ルール
+
+semgrep ルールパックを同梱しています。LLM が出力しがちな脆弱パターンに特化したもので、全ルールに `semgrep --test` のテストケース付きです。
+
+- **Python**: ハードコード認証情報 / SQL 文字列結合 / Flask センシティブルートの認証欠落 / `yaml.load` / `eval(input())` / `shell=True` 結合
+- **JS/TS**: `dangerouslySetInnerHTML` / `innerHTML` 補間 / Express ルートのミドルウェア欠落 / CORS ワイルドカード + credentials / 不安全 Cookie / `eval`
+- **Rust**: `mem::transmute` / `static mut` / 根拠のない `unsafe` / spawn 内 `unwrap`
+- **Go**: 空のエラーチェック / エラー破棄 / goroutine のループ変数キャプチャ / シェル文字列結合
+
+# 特徴 2: 日本のクラウドサービス対応
+
+グローバルのシークレットスキャナーは AWS や Stripe には強い一方、国内サービスのキーはスルーしがちです。ShipSafe は gitleaks の拡張ルールとして以下を同梱しています。
+
+- さくらのクラウド API トークン (重大)
+- LINE Messaging API チャネルアクセストークン / シークレット
+- PayPay API キー
+- freee アクセストークン
+- kintone API トークン
+
+`--lang ja` で出力も完全に日本語化されます (重要度は 重大/高/中/低)。
+
+# 特徴 3: GitHub Actions に 1 行
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: baneido/shipsafe@v1
+    with:
+      fail-on: high
+      lang: ja
+```
+
+これだけで:
+
+- PR に **サマリーコメント** (再実行時は同じコメントを更新、重複しない)
+- 変更行への **インラインレビューコメント**
+- SARIF を **Security タブ** にアップロード
+- しきい値超過で **ビルドを失敗** させる
+
+# ドッグフーディングで自分のバグを検出した話
+
+開発中、ShipSafe 自身のリポジトリを ShipSafe でスキャンする self-scan CI を組んだところ、初回実行で **自分のコードの問題を検出してビルドが落ちました**。
+
+1. `action.yml` の `run:` に `${{ inputs.* }}` を直接埋め込んでいた (GitHub Actions の shell injection パターン)
+2. Dockerfile に非 root `USER` がなかった
+
+どちらも修正してからマージしました。セキュリティツールが自分のゲートを通れないままリリースするわけにはいかないので、地味に効くプラクティスです。
+
+# 正直な注意点
+
+- ShipSafe は **オーケストレーター** です。semgrep / trivy / gitleaks は別途インストールが必要です (`shipsafe doctor` で確認、なければ警告してスキップ)
+- 名前から想像される「AI によるトリアージ・修正提案」は **v0.2 のロードマップ** で、v0.1 にはまだありません。v0.1 は決定的なゲートに集中しています
+- 検出は各エンジンの能力に依存します。誤検知は `allow-patterns` / `disabled-rules` / glob exclude で制御できます
+
+# インストール
+
+```bash
+brew install baneido/tap/shipsafe   # Homebrew
+cargo install shipsafe               # Cargo
+docker pull ghcr.io/baneido/shipsafe # Docker
+```
+
+MIT ライセンスです。誤検知の報告・ルールの追加 PR を歓迎します!
+
+https://github.com/baneido/shipsafe

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,36 @@
+# shipsafe.dev landing page
+
+Static, dependency-free landing page (single `index.html`).
+
+## Local preview
+
+```sh
+python3 -m http.server -d site 8000
+# → http://localhost:8000
+```
+
+## Deploy
+
+The page deploys automatically to **GitHub Pages** via
+`.github/workflows/pages.yml` on every push to `main`
+(https://baneido.github.io/shipsafe/).
+
+For the `shipsafe.dev` custom domain (manual, one-time):
+
+1. Buy `shipsafe.dev` (Google Domains / Cloudflare / お名前.com).
+2. Option A — GitHub Pages: add a `CNAME` file containing `shipsafe.dev`
+   to this directory and configure the domain in repo Settings → Pages;
+   point DNS `A`/`AAAA` at GitHub Pages or `CNAME` at
+   `baneido.github.io`.
+3. Option B — Vercel: `vercel --prod site/` and assign the domain in the
+   Vercel dashboard.
+4. `install.shipsafe.dev` should serve
+   [`scripts/install.sh`](../scripts/install.sh) — e.g. a Cloudflare
+   redirect rule to
+   `https://raw.githubusercontent.com/baneido/shipsafe/main/scripts/install.sh`.
+
+## Contact form
+
+The form opens a pre-filled mail draft to `contact@baneido.com` (static
+fallback). To switch to a hosted backend, create a Formspree form and put
+its endpoint in the `<form action=...>`.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ShipSafe — Pre-Deploy Security Gate</title>
+<meta name="description" content="コード・依存関係・シークレットをデプロイ前に一括スキャン。SAST + SCA + Secret 検出をワンコマンドで。GitHub Actions に 1 行で導入。">
+<meta property="og:title" content="ShipSafe — Pre-Deploy Security Gate">
+<meta property="og:description" content="SAST + SCA + Secret 検出をワンコマンドで。100k 行を約 6 秒でスキャン。">
+<meta property="og:type" content="website">
+<style>
+:root{
+  --bg:#0b0f14;--bg2:#111823;--fg:#e6edf3;--muted:#8b98a5;
+  --accent:#ff4d4d;--accent2:#3fb950;--card:#151d29;--border:#27313f;
+  --mono:'SFMono-Regular',ui-monospace,'Cascadia Mono',Menlo,Consolas,monospace;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Hiragino Sans','Noto Sans JP',sans-serif;line-height:1.7}
+a{color:inherit}
+.container{max-width:1040px;margin:0 auto;padding:0 24px}
+header{padding:20px 0;border-bottom:1px solid var(--border)}
+header .container{display:flex;align-items:center;justify-content:space-between}
+.logo{font-weight:800;font-size:1.25rem;display:flex;align-items:center;gap:8px}
+.logo span{color:var(--accent)}
+nav a{color:var(--muted);text-decoration:none;margin-left:24px;font-size:.95rem}
+nav a:hover{color:var(--fg)}
+.btn{display:inline-block;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:700;font-size:1rem}
+.btn-primary{background:var(--accent);color:#fff}
+.btn-primary:hover{background:#ff6666}
+.btn-ghost{border:1px solid var(--border);color:var(--fg)}
+.btn-ghost:hover{border-color:var(--muted)}
+.hero{padding:96px 0 64px;text-align:center}
+.hero h1{font-size:clamp(2rem,5.5vw,3.4rem);font-weight:900;letter-spacing:-.02em;line-height:1.25}
+.hero h1 em{font-style:normal;color:var(--accent)}
+.hero p.sub{color:var(--muted);font-size:1.15rem;max-width:640px;margin:20px auto 36px}
+.hero .ctas{display:flex;gap:16px;justify-content:center;flex-wrap:wrap}
+.badges{margin-top:28px;color:var(--muted);font-size:.9rem}
+.terminal{background:#0d1117;border:1px solid var(--border);border-radius:12px;max-width:760px;margin:56px auto 0;text-align:left;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,.5)}
+.terminal-bar{background:var(--bg2);padding:10px 16px;display:flex;gap:8px}
+.terminal-bar i{width:12px;height:12px;border-radius:50%;display:inline-block}
+.terminal-bar i:nth-child(1){background:#ff5f57}.terminal-bar i:nth-child(2){background:#febc2e}.terminal-bar i:nth-child(3){background:#28c840}
+.terminal pre{padding:20px 24px;font-family:var(--mono);font-size:.85rem;line-height:1.6;overflow-x:auto;min-height:330px}
+.t-dim{color:#8b98a5}.t-red{color:#ff6b6b;font-weight:700}.t-yellow{color:#ffd866}.t-green{color:#3fb950}.t-cyan{color:#56d4dd}
+section{padding:72px 0;border-top:1px solid var(--border)}
+h2{font-size:2rem;font-weight:800;text-align:center;margin-bottom:12px}
+.section-sub{text-align:center;color:var(--muted);margin-bottom:48px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:20px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:28px}
+.card h3{font-size:1.1rem;margin-bottom:10px}
+.card p{color:var(--muted);font-size:.95rem}
+.card .icon{font-size:1.6rem;margin-bottom:12px;display:block}
+.code{background:#0d1117;border:1px solid var(--border);border-radius:10px;padding:18px 20px;font-family:var(--mono);font-size:.85rem;overflow-x:auto;color:#c9d1d9}
+.code .c{color:#8b98a5}
+.install .grid{grid-template-columns:repeat(auto-fit,minmax(420px,1fr))}
+.pricing .grid{grid-template-columns:repeat(auto-fit,minmax(280px,1fr));max-width:880px;margin:0 auto}
+.price{font-size:2.2rem;font-weight:900;margin:12px 0}
+.price small{font-size:.95rem;color:var(--muted);font-weight:400}
+.plan ul{list-style:none;margin:18px 0 24px}
+.plan li{padding:6px 0;color:var(--muted);font-size:.95rem}
+.plan li::before{content:"✓ ";color:var(--accent2);font-weight:700}
+.plan.featured{border-color:var(--accent)}
+.tag{display:inline-block;background:rgba(255,77,77,.12);color:var(--accent);font-size:.75rem;font-weight:700;padding:2px 10px;border-radius:999px;margin-left:8px}
+.contact form{max-width:560px;margin:0 auto;display:grid;gap:14px}
+input,textarea{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:12px 14px;color:var(--fg);font-size:1rem;font-family:inherit}
+input:focus,textarea:focus{outline:none;border-color:var(--accent)}
+footer{padding:40px 0;border-top:1px solid var(--border);color:var(--muted);font-size:.9rem;text-align:center}
+footer a{color:var(--muted)}
+@media(max-width:640px){nav{display:none}}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <div class="logo">🛡️ Ship<span>Safe</span></div>
+    <nav>
+      <a href="#features">機能</a>
+      <a href="#install">インストール</a>
+      <a href="#pricing">料金</a>
+      <a href="#contact">お問合せ</a>
+      <a href="https://github.com/baneido/shipsafe">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+<div class="hero container">
+  <h1>デプロイ前に、<em>ワンコマンド</em>で<br>セキュリティゲート。</h1>
+  <p class="sub">SAST・依存関係・シークレット検出を 1 つの CLI に統合。AI が生成しがちな脆弱パターンに特化したルールと日本のクラウドサービス対応。100k 行を約 6 秒でスキャン。</p>
+  <div class="ctas">
+    <a class="btn btn-primary" href="https://github.com/baneido/shipsafe#installation">今すぐインストール</a>
+    <a class="btn btn-ghost" href="https://github.com/baneido/shipsafe">GitHub で見る →</a>
+  </div>
+  <div class="badges">MIT License · Rust 製 · GitHub Actions 対応 · 日本語対応</div>
+
+  <div class="terminal">
+    <div class="terminal-bar"><i></i><i></i><i></i></div>
+    <pre id="demo"></pre>
+  </div>
+</div>
+
+<section id="features">
+  <div class="container">
+    <h2>3 つのスキャナー、1 つのゲート</h2>
+    <p class="section-sub">semgrep / trivy / gitleaks を並列実行し、結果を正規化・重複排除して 1 つのレポートに。</p>
+    <div class="grid">
+      <div class="card"><span class="icon">🔍</span><h3>SAST</h3><p>semgrep による静的解析。OWASP Top 10 に加え、Copilot / Cursor / ChatGPT が生成しがちな脆弱パターン (SQL 文字列結合、認証チェック欠落、XSS シンク、unsafe 乱用など) を Python / JS / TS / Rust / Go 向けに同梱。</p></div>
+      <div class="card"><span class="icon">📦</span><h3>SCA</h3><p>trivy による依存関係スキャン。npm / pip / cargo / gem / go mod の CVE を検出し、修正バージョンを提示。重要度しきい値でビルドを制御。</p></div>
+      <div class="card"><span class="icon">🔑</span><h3>Secrets</h3><p>gitleaks による 800+ パターンのシークレット検出。さくらのクラウド・LINE・PayPay・freee・kintone など日本のサービスにも対応。Git 履歴スキャンも可能。</p></div>
+      <div class="card"><span class="icon">💬</span><h3>PR コメント</h3><p>GitHub Actions に 1 行追加するだけで、PR にサマリーと変更行へのインラインコメントを自動投稿。SARIF は Security タブに統合。</p></div>
+      <div class="card"><span class="icon">⚡</span><h3>高速</h3><p>3 つのスキャナーを非同期並列実行。10 万行のリポジトリを約 6 秒でスキャン (実測)。タイムアウトとリトライで CI を安定運用。</p></div>
+      <div class="card"><span class="icon">🇯🇵</span><h3>日本語ネイティブ</h3><p><code>--lang ja</code> で出力を完全日本語化。重要度ラベル (重大/高/中/低)、エラーメッセージ、修正提案まで日本語で。</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="install" class="install">
+  <div class="container">
+    <h2>30 秒で導入</h2>
+    <p class="section-sub">CLI でローカルに、または GitHub Actions に 1 行で。</p>
+    <div class="grid">
+      <div>
+        <h3 style="margin-bottom:12px">CLI</h3>
+        <div class="code"><span class="c"># Homebrew</span><br>brew install baneido/tap/shipsafe<br><br><span class="c"># または Cargo</span><br>cargo install shipsafe<br><br><span class="c"># スキャン実行</span><br>shipsafe scan --lang ja</div>
+      </div>
+      <div>
+        <h3 style="margin-bottom:12px">GitHub Actions</h3>
+        <div class="code">steps:<br>&nbsp;&nbsp;- uses: actions/checkout@v4<br>&nbsp;&nbsp;- uses: <span class="t-cyan">baneido/shipsafe@v1</span><br>&nbsp;&nbsp;&nbsp;&nbsp;with:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fail-on: high<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lang: ja</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="pricing" class="pricing">
+  <div class="container">
+    <h2>料金プラン</h2>
+    <p class="section-sub">コア機能はずっと無料・オープンソース。</p>
+    <div class="grid">
+      <div class="card plan">
+        <h3>Open Source</h3>
+        <div class="price">¥0 <small>/ ずっと無料</small></div>
+        <ul>
+          <li>SAST + SCA + Secrets スキャン</li>
+          <li>AI 生成コード検出ルール</li>
+          <li>日本クラウドサービス対応</li>
+          <li>GitHub Actions / PR コメント</li>
+          <li>SARIF / JSON 出力</li>
+          <li>MIT ライセンス</li>
+        </ul>
+        <a class="btn btn-primary" href="https://github.com/baneido/shipsafe#installation">無料で始める</a>
+      </div>
+      <div class="card plan featured">
+        <h3>Pro <span class="tag">Coming Soon</span></h3>
+        <div class="price">近日公開</div>
+        <ul>
+          <li>AI ノイズ除去 (reachability トリアージ)</li>
+          <li>AI 修正提案 (PR コメント)</li>
+          <li>SBOM 生成 (CycloneDX / SPDX)</li>
+          <li>組織ダッシュボード</li>
+          <li>優先サポート</li>
+        </ul>
+        <a class="btn btn-ghost" href="#contact">ウェイトリストに登録</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="contact" class="contact">
+  <div class="container">
+    <h2>お問合せ</h2>
+    <p class="section-sub">導入のご相談・Pro ウェイトリスト・フィードバックはこちらから。</p>
+    <form action="https://formspree.io/f/shipsafe" method="POST" onsubmit="return mailFallback(this)">
+      <input type="text" name="name" placeholder="お名前" required>
+      <input type="email" name="email" placeholder="メールアドレス" required>
+      <textarea name="message" rows="5" placeholder="メッセージ" required></textarea>
+      <button class="btn btn-primary" type="submit">送信する</button>
+    </form>
+    <p style="text-align:center;color:var(--muted);margin-top:20px;font-size:.9rem">
+      バグ報告・機能要望は <a href="https://github.com/baneido/shipsafe/issues">GitHub Issues</a> へ。<br>
+      メール: <a href="mailto:contact@baneido.com">contact@baneido.com</a>
+    </p>
+  </div>
+</section>
+</main>
+
+<footer>
+  <div class="container">
+    🛡️ ShipSafe — Built with ❤️ by <a href="https://baneido.com">Baneido, Inc.</a> ·
+    <a href="https://github.com/baneido/shipsafe">GitHub</a> ·
+    <a href="https://github.com/baneido/shipsafe/blob/main/LICENSE">MIT License</a>
+  </div>
+</footer>
+
+<script>
+// Simulated CLI demo (typed line by line).
+const LINES = [
+  ['t-dim', '$ '], ['', 'shipsafe scan --lang ja --fail-on high\n\n'],
+  ['', '  '], ['t-cyan', 'ShipSafe'], ['', ' v0.1.0 — Pre-Deploy Security Gate\n\n'],
+  ['', '  ▶ SAST       ... '], ['t-yellow', '検出 2 件 (重大 1 件, 中 1 件)\n'],
+  ['', '  ▶ SCA        ... '], ['t-yellow', '検出 1 件 (高 1 件)\n'],
+  ['', '  ▶ Secrets    ... '], ['t-yellow', '検出 1 件 (高 1 件)\n\n'],
+  ['t-red', '!! 重大'], ['', '  ai-py-sql-injection-concat\n'],
+  ['t-dim', '   場所: app.py:17 — SQL クエリの文字列結合\n\n'],
+  ['t-yellow', '!. 高'], ['', '  LINE API Credential detected\n'],
+  ['t-dim', '   場所: config.py:4 | CWE-798\n'],
+  ['t-green', '   修正案:'], ['', ' シークレットを削除し、直ちにローテーションしてください\n\n'],
+  ['t-dim', '====================================================\n'],
+  ['', '集計: 検出 4 件 | 重大 1 | 高 2 | 中 1 | 低 0\n\n'],
+  ['t-red', '✘ ビルド失敗:'], ['', ' 重要度しきい値 (--fail-on high) 以上の検出が 3 件あります\n'],
+];
+const el = document.getElementById('demo');
+let li = 0, ci = 0;
+function tick() {
+  if (li >= LINES.length) return;
+  const [cls, text] = LINES[li];
+  if (ci === 0 && cls) { el.insertAdjacentHTML('beforeend', `<span class="${cls}"></span>`); }
+  const target = cls ? el.lastElementChild : el;
+  const ch = text[ci++];
+  if (cls) target.textContent += ch; else el.insertAdjacentText('beforeend', ch);
+  if (ci >= text.length) { li++; ci = 0; }
+  setTimeout(tick, li < 2 ? 45 : 8);
+}
+tick();
+function mailFallback(form) {
+  // Static fallback: open a mail draft instead of posting to a form backend.
+  const n = form.name.value, e = form.email.value, m = form.message.value;
+  location.href = `mailto:contact@baneido.com?subject=${encodeURIComponent('[ShipSafe] お問合せ from ' + n)}&body=${encodeURIComponent(m + '\n\n— ' + n + ' <' + e + '>')}`;
+  return false;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **#31 ランディングページ**: `site/index.html` — 依存ゼロの静的 LP (CLI デモアニメーション、機能、インストール、料金プラン (OSS 無料 / Pro Coming Soon + ウェイトリスト)、お問合せフォーム)。`pages.yml` で main へのプッシュ時に GitHub Pages へ自動デプロイ。shipsafe.dev ドメイン設定手順は `site/README.md` に記載 (ドメイン取得のみ手動)。
- **#33 ローンチ準備**: `docs/launch/` に Product Hunt 投稿文 + メーカーコメント、Show HN ドラフト、X 告知スレッド (日英)、Zenn 記事 (published: false ドラフト) を用意。
- **#15 (準備)**: Marketplace 公開ランブック (`docs/launch/marketplace.md`) — カテゴリ Security / Code quality、リリース UI での公開手順、v1 メジャータグ運用。

## Test plan
- LP をローカルプレビューで確認 (デモアニメーション・フォーム fallback 動作)
- pages.yml は YAML 検証済み、マージ後の Pages 有効化で実走

Closes #31
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)