### PR TITLE
Deploy landing page via gh-pages branch (policy-compliant)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,15 +1,17 @@
 name: Deploy landing page to GitHub Pages
 
+# Deploys site/ to the gh-pages branch. The repo's Actions policy requires
+# SHA-pinned actions (transitively), which the official Pages actions break
+# by referencing actions/upload-artifact by tag internally — so we publish
+# via a plain git push instead.
 on:
   push:
     branches: [main]
-    paths: ['site/**']
+    paths: ['site/**', '.github/workflows/pages.yml']
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
@@ -17,15 +19,18 @@ concurrency:
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
-        with:
-          path: site/
-      - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+      - name: Publish site/ to gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd site
+          git init -q -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          touch .nojekyll
+          git add -A
+          git commit -qm "Deploy landing page from $GITHUB_SHA"
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ LABEL org.opencontainers.image.title="ShipSafe" \
       org.opencontainers.image.source="https://github.com/baneido/shipsafe" \
       org.opencontainers.image.licenses="MIT"
 
-ARG TRIVY_VERSION=v0.58.1
+ARG TRIVY_VERSION=0.58.1
 ARG GITLEAKS_VERSION=8.30.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip ca-certificates curl git \
     && pip3 install --no-cache-dir --break-system-packages semgrep \
-    && curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-       | sh -s -- -b /usr/local/bin ${TRIVY_VERSION} \
+    && curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+       | tar -xz -C /usr/local/bin trivy \
     && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
        | tar -xz -C /usr/local/bin gitleaks \
     && apt-get purge -y --auto-remove curl \


### PR DESCRIPTION
## Summary
公式 Pages actions (`upload-pages-artifact`) は内部で `actions/upload-artifact@v4` をタグ参照しており、SHA ピン必須ポリシーに推移的に違反してデプロイが失敗していました。素の `git push` で `gh-pages` ブランチへ公開する方式に変更します (Pages のソース設定も branch 方式へ切替)。

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)