### PR TITLE
Fix Docker glibc mismatch (build on bookworm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build stage -----------------------------------------------------------
-FROM rust:1-slim AS builder
+FROM rust:1-slim-bookworm AS builder
 WORKDIR /app
 
 # Cache the dependency graph: build a dummy main against the real manifests


### PR DESCRIPTION
`rust:1-slim` が trixie ベースになり、生成バイナリが GLIBC_2.39 を要求して bookworm ランタイムで起動不能でした (スモークテストが検出)。builder を `rust:1-slim-bookworm` に固定。

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)