### PR TITLE
ci: crates.io OIDC publish + zizmor workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Rust (stable)
         run: rustup toolchain install stable --profile minimal && rustup default stable
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -39,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Rust (stable)
         run: rustup toolchain install stable --profile minimal && rustup default stable
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -82,6 +86,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Rust (stable)
         run: |
           rustup toolchain install stable --profile minimal
@@ -101,3 +107,26 @@ jobs:
         with:
           name: shipsafe-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/shipsafe
+
+  # Static analysis of our own GitHub Actions workflows. Pinned to a known
+  # version so a new zizmor release adding audits can't break CI unexpectedly;
+  # bump deliberately. Installed via pip to keep the Actions SHA-pin policy simple.
+  zizmor:
+    name: Audit workflows (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+      - name: Install zizmor
+        run: pip install zizmor==1.25.2
+      - name: Run zizmor
+        env:
+          # Enables online audits (resolving action refs against GitHub).
+          GH_TOKEN: ${{ github.token }}
+        run: zizmor .github/workflows/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '28 20 * * 5'
 
+# Least privilege at the workflow level; the analyze job grants its own scopes.
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -58,6 +61,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,8 +10,8 @@ on:
     paths: ['site/**', '.github/workflows/pages.yml']
   workflow_dispatch:
 
-permissions:
-  contents: write
+# Least privilege at the workflow level; the deploy job opts into what it needs.
+permissions: {}
 
 concurrency:
   group: pages
@@ -20,8 +20,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # force-push the built site to the gh-pages branch
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Publish site/ to gh-pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,8 @@ on:
         description: 'Tag to build and publish (e.g. v0.1.0)'
         required: true
 
-permissions:
-  contents: write
-  packages: write
+# Least privilege at the workflow level; each job opts into only what it needs.
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +19,8 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.target }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +38,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Rust (stable)
         shell: bash
         run: |
@@ -69,8 +72,12 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-*
@@ -100,8 +107,13 @@ jobs:
   docker:
     name: Push Docker image to ghcr.io
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Log in to ghcr.io
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -128,26 +140,34 @@ jobs:
   crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Trusted Publishing: scope id-token to this job only (overrides top-level perms).
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Rust (stable)
         run: rustup toolchain install stable --profile minimal && rustup default stable
+      - name: Authenticate to crates.io (Trusted Publishing / OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
-            echo "::warning::CARGO_REGISTRY_TOKEN not set — skipping crates.io publish"
-            exit 0
-          fi
-          cargo publish --locked
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked
 
   homebrew:
     name: Update Homebrew formula
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Update baneido/homebrew-tap
         env:
           TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/shipsafe.yml
+++ b/.github/workflows/shipsafe.yml
@@ -9,16 +9,20 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  security-events: write
-  pull-requests: write
+# Least privilege at the workflow level; the scan job opts into what it needs.
+permissions: {}
 
 jobs:
   shipsafe:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # checkout
+      security-events: write  # upload SARIF to the Security tab
+      pull-requests: write    # post scan results as PR comments
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: ShipSafe scan (local action)
         uses: ./
         with:


### PR DESCRIPTION
## 概要

crates.io への publish を **Trusted Publishing (OIDC)** に切り替え、全 GitHub Actions ワークフローを **zizmor** で強化しました。zizmor デフォルトペルソナ（オンライン監査込み）で findings ゼロです。さらに退行防止のため **zizmor のブロッキングCIゲート** を追加しています。

## 変更点

### crates.io Trusted Publishing (OIDC)
- `secrets.CARGO_REGISTRY_TOKEN` を廃止し、`rust-lang/crates-io-auth-action`（SHAピン留め, v1.0.5）で OIDC → 短命トークンを取得
- `id-token: write` は `crates` ジョブにのみ付与
- ⚠️ **別途設定が必要**: crates.io 側で Trusted Publisher の登録（owner: `baneido` / repo: `shipsafe` / workflow: `release.yml`）。登録までは publish が認証エラーになります

### zizmor によるワークフロー強化
- **`artipacked`** (Medium×11): 全 `actions/checkout` に `persist-credentials: false`。pages/homebrew の push は明示トークン使用のため影響なしを確認済み
- **`excessive-permissions`** (High×2 + pedantic 4): ワークフローレベルの write 権限を `permissions: {}` にし、各ジョブが最小権限をオプトイン（`release.yml` / `pages.yml` / `shipsafe.yml`）。`codeql.yml` にトップレベル `permissions: {}` を追加。各権限に用途コメント
- `template-injection`（pedantic 13件）は全て `${{ matrix.target }}` の静的マトリクス値で未信頼入力ではないため対応不要と判断

### CIゲート
- `ci.yml` に zizmor ジョブを追加（`zizmor==1.25.2` にピン留め、pip 導入でアクションSHAピン留めポリシーに非抵触）。findings 検出でCI失敗

## 検証
- 全ワークフローの YAML 妥当性チェック: OK
- `zizmor .github/workflows/`（デフォルト, オンライン）: **No findings**
- `zizmor --persona=pedantic` の `excessive-permissions`: **0件**

🤖 Generated with [Claude Code](https://claude.com/claude-code)