### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "shipsafe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipsafe"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Baneido <contact@baneido.com>"]
 description = "AI-Powered Pre-Deploy Security Gate"


### PR DESCRIPTION
## Why

The `v0.2.1` tag was pushed while `Cargo.toml` still declared `0.2.0`. The Release workflow's `crates` job therefore failed:

```
error: crate shipsafe@0.2.0 already exists on crates.io index
```

(0.2.0 was already published at the v0.2.0 release.)

## What

- `Cargo.toml`: `version = "0.2.0"` → `"0.2.1"`
- `Cargo.lock`: sync `shipsafe` package entry to `0.2.1` (keeps `cargo publish --locked` consistent)

After merge, the `v0.2.1` tag will be re-pointed at this commit to re-trigger the release with a publishable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)