### PR TITLE
fix(release): update homebrew-tap via PR instead of direct push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,11 +206,21 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
 
           export GH_TOKEN="$TAP_TOKEN"
-          gh pr create \
+          # Open a PR, or reuse an existing one (e.g. on a re-run). Only treat a
+          # pre-existing PR as success — any other failure (no permission,
+          # network error) must abort so we don't print a misleading merge
+          # warning for a PR that was never created.
+          if ! gh pr create \
             --title "shipsafe ${VERSION}" \
             --body "Automated Homebrew formula update for shipsafe ${VERSION}." \
-            --head "$BRANCH" --base main \
-            || echo "PR for ${BRANCH} already exists — reusing it"
+            --head "$BRANCH" --base main; then
+            if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+              echo "PR for ${BRANCH} already exists — reusing it"
+            else
+              echo "::error::Failed to create Homebrew formula PR for ${VERSION}"
+              exit 1
+            fi
+          fi
 
           # Merge automatically to keep the release flow hands-off. Falls back to
           # enabling auto-merge, and finally leaves the PR open if the bot lacks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,30 @@ jobs:
           cd tap
           git config user.name "shipsafe-release-bot"
           git config user.email "contact@baneido.com"
+
+          # The tap's main branch is protected (changes must go through a PR),
+          # so we open a PR from a release branch instead of pushing to main.
           git add Formula/shipsafe.rb
-          git commit -m "shipsafe ${VERSION}" || echo "no changes"
-          git push
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for ${VERSION} — nothing to do"
+            exit 0
+          fi
+
+          BRANCH="shipsafe-${VERSION}"
+          git checkout -b "$BRANCH"
+          git commit -m "shipsafe ${VERSION}"
+          git push --force-with-lease origin "$BRANCH"
+
+          export GH_TOKEN="$TAP_TOKEN"
+          gh pr create \
+            --title "shipsafe ${VERSION}" \
+            --body "Automated Homebrew formula update for shipsafe ${VERSION}." \
+            --head "$BRANCH" --base main \
+            || echo "PR for ${BRANCH} already exists — reusing it"
+
+          # Merge automatically to keep the release flow hands-off. Falls back to
+          # enabling auto-merge, and finally leaves the PR open if the bot lacks
+          # the permission to merge.
+          gh pr merge "$BRANCH" --squash --delete-branch --admin \
+            || gh pr merge "$BRANCH" --squash --delete-branch --auto \
+            || echo "::warning::Homebrew formula PR for ${VERSION} opened but not merged — merge it manually"


### PR DESCRIPTION
## 背景

`Release` ワークフローの `homebrew` ジョブが、`baneido/homebrew-tap` の `main` へ直接 `git push` していたため、tap 側のリポジトリルール（"Changes must be made through a pull request"）に違反してリリースが失敗していました。

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

## 変更内容

`homebrew` ジョブを直接 push から **PR 経由** に変更しました。

1. **差分チェック** — formula に変更がなければ何もせず終了
2. **ブランチ作成** — `shipsafe-${VERSION}` ブランチにコミット
3. **ブランチ push** — `--force-with-lease` で push（再実行に対応）
4. **PR 作成** — `gh pr create` で `main` 向けに PR を作成（既存 PR は再利用）
5. **自動マージ** — `gh pr merge --admin` → 失敗時 `--auto` → それも不可なら警告を出して PR を残す

## 注意：`TAP_GITHUB_TOKEN` の権限

完全自動で動かすには `TAP_GITHUB_TOKEN` に以下が必要です。

- PR 作成: `homebrew-tap` への `Contents: write` / `Pull requests: write`
- 自動マージ (`--admin`): ルールを bypass できる権限（管理者権限、または bypass リストへの bot 登録）

権限が不足する場合は PR が開いたまま残り、警告ログが出ます（手動マージが必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)