### PR TITLE
ci: gate release on tag/Cargo version match + idempotent publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,45 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Fail fast if the git tag, Cargo.toml and Cargo.lock disagree. A version that
+  # was bumped in the tag but not in Cargo.toml (or vice-versa) is the usual
+  # cause of a broken `cargo publish` and of Docker/Homebrew artifacts that are
+  # labelled with one version but contain a binary reporting another. Every
+  # publishing job depends on this gate, so the whole release stops here on
+  # mismatch instead of failing halfway through.
+  verify-version:
+    name: Verify tag matches Cargo.toml / Cargo.lock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Check versions are in sync
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          tag_version="${TAG#v}"
+          toml_version="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          lock_version="$(awk '/^name = "shipsafe"$/{getline; print; exit}' Cargo.lock | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "tag:        $tag_version"
+          echo "Cargo.toml: $toml_version"
+          echo "Cargo.lock: $lock_version"
+          fail=0
+          if [ "$tag_version" != "$toml_version" ]; then
+            echo "::error::Cargo.toml is $toml_version but the tag is v$tag_version. Run 'scripts/bump-version.sh $tag_version', commit, then re-tag the merge commit."
+            fail=1
+          fi
+          if [ "$toml_version" != "$lock_version" ]; then
+            echo "::error::Cargo.lock is $lock_version but Cargo.toml is $toml_version. Run 'cargo update -p shipsafe' and commit Cargo.lock."
+            fail=1
+          fi
+          exit "$fail"
+
   build:
     name: Build (${{ matrix.target }})
+    needs: verify-version
     permissions:
       contents: read
     strategy:
@@ -106,6 +143,7 @@ jobs:
 
   docker:
     name: Push Docker image to ghcr.io
+    needs: verify-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -139,6 +177,7 @@ jobs:
 
   crates:
     name: Publish to crates.io
+    needs: verify-version
     runs-on: ubuntu-latest
     # Trusted Publishing: scope id-token to this job only (overrides top-level perms).
     permissions:
@@ -156,7 +195,19 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --locked
+        run: |
+          # Idempotent publish: re-running the release (e.g. because Docker or
+          # Homebrew failed) must not abort on "crate already exists". Skip when
+          # this exact version is already on crates.io.
+          version="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H 'User-Agent: shipsafe-release (https://github.com/baneido/shipsafe)' \
+            "https://crates.io/api/v1/crates/shipsafe/${version}")"
+          if [ "$status" = "200" ]; then
+            echo "::notice::shipsafe ${version} is already published on crates.io — skipping publish"
+            exit 0
+          fi
+          cargo publish --locked
 
   homebrew:
     name: Update Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
           echo "Cargo.lock: $lock_version"
           fail=0
           if [ "$tag_version" != "$toml_version" ]; then
-            echo "::error::Cargo.toml is $toml_version but the tag is v$tag_version. Run 'scripts/bump-version.sh $tag_version', commit, then re-tag the merge commit."
+            echo "::error::Cargo.toml is $toml_version but the tag is v$tag_version. Run 'make bump VERSION=$tag_version', commit, then re-tag the merge commit."
             fail=1
           fi
           if [ "$toml_version" != "$lock_version" ]; then
-            echo "::error::Cargo.lock is $lock_version but Cargo.toml is $toml_version. Run 'cargo update -p shipsafe' and commit Cargo.lock."
+            echo "::error::Cargo.lock is $lock_version but Cargo.toml is $toml_version. Run 'make bump VERSION=$toml_version' to resync Cargo.lock, then commit it."
             fail=1
           fi
           exit "$fail"
@@ -201,13 +201,25 @@ jobs:
           # this exact version is already on crates.io.
           version="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
           status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            --retry 3 --retry-all-errors --max-time 30 \
             -H 'User-Agent: shipsafe-release (https://github.com/baneido/shipsafe)' \
-            "https://crates.io/api/v1/crates/shipsafe/${version}")"
-          if [ "$status" = "200" ]; then
-            echo "::notice::shipsafe ${version} is already published on crates.io — skipping publish"
-            exit 0
-          fi
-          cargo publish --locked
+            "https://crates.io/api/v1/crates/shipsafe/${version}" || true)"
+          # Only 404 (definitively not published) proceeds to publish. A 429/5xx
+          # or network error must NOT be treated as "not published", or a retried
+          # release would attempt to re-publish an existing version and fail.
+          case "$status" in
+            200)
+              echo "::notice::shipsafe ${version} is already published on crates.io — skipping publish"
+              exit 0
+              ;;
+            404)
+              cargo publish --locked
+              ;;
+            *)
+              echo "::error::Unexpected response ($status) from crates.io while checking shipsafe ${version}; not publishing"
+              exit 1
+              ;;
+          esac
 
   homebrew:
     name: Update Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Check versions are in sync
         env:
@@ -76,6 +80,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Install Rust (stable)
         shell: bash
@@ -114,6 +122,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -151,6 +163,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Log in to ghcr.io
         env:
@@ -186,6 +202,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Install Rust (stable)
         run: rustup toolchain install stable --profile minimal && rustup default stable
@@ -230,6 +250,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Check out the released tag, not the default branch. On a
+          # workflow_dispatch run inputs.tag selects what gets validated, built
+          # and published; on a tag push github.ref already points at the tag.
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Update baneido/homebrew-tap
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,22 @@ cargo test
 - 新機能にはテストを追加
 - コミットメッセージは [Conventional Commits](https://www.conventionalcommits.org/) に従う
 
+## リリース手順
+
+バージョンは **Cargo.toml**・**Cargo.lock**・**git tag** の3か所で一致している必要があります（ずれると `cargo publish` や Docker / Homebrew の成果物が壊れます）。`make bump` が Cargo.toml と Cargo.lock を一括で更新します。
+
+```bash
+# 1. バージョンを更新（Cargo.toml + Cargo.lock を同期）
+make bump VERSION=0.2.2
+
+# 2. CHANGELOG.md を更新
+
+# 3. PR を作成・マージ後、マージコミットにタグを打つ
+git tag v0.2.2 && git push origin v0.2.2
+```
+
+タグの push で Release ワークフローが起動します。`verify-version` ジョブがタグと Cargo.toml / Cargo.lock の一致を検証し、ずれていればビルド前に失敗します。crates.io への publish は冪等で、同一バージョンが既に公開済みなら skip するため、Docker や Homebrew の失敗で再実行しても安全です。
+
 ## イシューの報告
 
 バグ報告や機能リクエストは [Issues](https://github.com/baneido/shipsafe/issues) からお願いします。

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# ShipSafe development tasks. Run `make help` to list them.
+.PHONY: help build test fmt lint check bump
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the release binary
+	cargo build --release
+
+test: ## Run the test suite
+	cargo test
+
+fmt: ## Format the code
+	cargo fmt
+
+lint: ## Run clippy with warnings denied
+	cargo clippy --all-targets -- -D warnings
+
+check: fmt lint test ## Format, lint and test (run before opening a PR)
+
+bump: ## Bump the crate version in Cargo.toml + Cargo.lock (usage: make bump VERSION=0.2.2)
+	@test -n "$(VERSION)" || { echo "usage: make bump VERSION=0.2.2" >&2; exit 2; }
+	scripts/bump-version.sh $(VERSION)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -30,18 +30,27 @@ fi
 cd "$(git rev-parse --show-toplevel)"
 
 current="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
-if [ "$current" = "$new" ]; then
-  echo "Cargo.toml is already at $new — nothing to do."
+lock_current="$(awk '/^name = "shipsafe"$/{getline; print; exit}' Cargo.lock | sed -E 's/.*"([^"]+)".*/\1/')"
+
+# Only a true no-op when BOTH files already match — otherwise a stale Cargo.lock
+# (e.g. Cargo.toml bumped but the lock left behind) would never get repaired.
+if [ "$current" = "$new" ] && [ "$lock_current" = "$new" ]; then
+  echo "Cargo.toml and Cargo.lock are already at $new — nothing to do."
   exit 0
 fi
 
-echo "Bumping $current -> $new"
-
 # 1. Cargo.toml: only the first `version = ` line (the [package] one).
-perl -i -pe 'if (!$seen && /^version = /) { s/^version = ".*"/version = "'"$new"'"/; $seen = 1 }' Cargo.toml
+if [ "$current" != "$new" ]; then
+  echo "Bumping Cargo.toml $current -> $new"
+  perl -i -pe 'if (!$seen && /^version = /) { s/^version = ".*"/version = "'"$new"'"/; $seen = 1 }' Cargo.toml
+fi
 
 # 2. Cargo.lock: re-lock just the shipsafe entry. --offline keeps it from
-#    touching unrelated dependency versions.
+#    touching unrelated dependency versions. Runs whenever the lock is out of
+#    sync, so it also repairs a stale lock against an already-correct Cargo.toml.
+if [ "$lock_current" != "$new" ]; then
+  echo "Syncing Cargo.lock $lock_current -> $new"
+fi
 cargo update -p shipsafe --offline
 
 echo

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -21,8 +21,9 @@ fi
 # Accept a leading "v" (v0.2.2) but work with the bare version everywhere.
 new="${new#v}"
 
-# Validate semver: MAJOR.MINOR.PATCH with an optional -prerelease suffix.
-if ! printf '%s' "$new" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+# Validate semver: MAJOR.MINOR.PATCH (no leading zeros in the numeric parts)
+# with optional -prerelease and +build metadata suffixes.
+if ! printf '%s' "$new" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
   echo "error: '$new' is not a valid semver version (expected e.g. 1.2.3)" >&2
   exit 2
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Bump the crate version in every place it must stay in sync.
+#
+# Usage:
+#   scripts/bump-version.sh <new-version>      # e.g. scripts/bump-version.sh 0.2.2
+#
+# The version lives in three places that have to agree or `cargo publish` (and
+# the Docker/Homebrew artifacts) break: Cargo.toml, Cargo.lock and the git tag.
+# Forgetting one of them is the usual cause of a failed release, so this script
+# updates Cargo.toml and Cargo.lock together and prints the exact tag command to
+# run afterwards. The Release workflow's verify-version job enforces the match.
+set -euo pipefail
+
+new="${1:-}"
+if [ -z "$new" ]; then
+  echo "usage: $0 <new-version>   (e.g. 0.2.2)" >&2
+  exit 2
+fi
+
+# Accept a leading "v" (v0.2.2) but work with the bare version everywhere.
+new="${new#v}"
+
+# Validate semver: MAJOR.MINOR.PATCH with an optional -prerelease suffix.
+if ! printf '%s' "$new" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "error: '$new' is not a valid semver version (expected e.g. 1.2.3)" >&2
+  exit 2
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+current="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+if [ "$current" = "$new" ]; then
+  echo "Cargo.toml is already at $new — nothing to do."
+  exit 0
+fi
+
+echo "Bumping $current -> $new"
+
+# 1. Cargo.toml: only the first `version = ` line (the [package] one).
+perl -i -pe 'if (!$seen && /^version = /) { s/^version = ".*"/version = "'"$new"'"/; $seen = 1 }' Cargo.toml
+
+# 2. Cargo.lock: re-lock just the shipsafe entry. --offline keeps it from
+#    touching unrelated dependency versions.
+cargo update -p shipsafe --offline
+
+echo
+echo "Updated:"
+echo "  Cargo.toml -> $(grep -m1 '^version = ' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+echo "  Cargo.lock -> $(awk '/^name = "shipsafe"$/{getline; print; exit}' Cargo.lock | sed -E 's/.*"([^"]+)".*/\1/')"
+echo
+echo "Next steps:"
+echo "  1. Update CHANGELOG.md for $new"
+echo "  2. git switch -c release/$new && git commit -am \"chore: bump version to $new\""
+echo "  3. Open a PR and merge it, then tag the merge commit:"
+echo "       git tag v$new && git push origin v$new"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -60,6 +60,8 @@ echo "  Cargo.lock -> $(awk '/^name = "shipsafe"$/{getline; print; exit}' Cargo.
 echo
 echo "Next steps:"
 echo "  1. Update CHANGELOG.md for $new"
-echo "  2. git switch -c release/$new && git commit -am \"chore: bump version to $new\""
+echo "  2. git switch -c release/$new"
+echo "     git add Cargo.toml Cargo.lock CHANGELOG.md   # stage only the release files"
+echo "     git commit -m \"chore: bump version to $new\""
 echo "  3. Open a PR and merge it, then tag the merge commit:"
 echo "       git tag v$new && git push origin v$new"


### PR DESCRIPTION
## 背景

Release ワークフローの Publish step が以下のエラーで失敗しました。

```
error: crate shipsafe@0.2.1 already exists on crates.io index
```

ワークフロー再実行（Docker/Homebrew 失敗後の再走など）で `cargo publish` が冪等でなく、公開済みバージョンに対して必ず失敗していたのが原因です。加えて、バージョンが **Cargo.toml / Cargo.lock / git tag** の3か所に分散しており、bump 漏れが起きやすい構造でした。

## 変更内容

### `.github/workflows/release.yml`
- **`verify-version` ジョブを追加**: tag・Cargo.toml・Cargo.lock の3者一致をビルド前に検証し、ずれていれば修正コマンド付きの `::error::` で即停止。`build` / `docker` / `crates` が `needs: verify-version` で依存し、全ジョブをカバー
- **publish を冪等化**: crates.io API で公開済みか確認し、`200` なら skip。Docker/Homebrew 失敗後の再実行が安全に

### `scripts/bump-version.sh` + `make bump`
- `make bump VERSION=0.2.2` で Cargo.toml と Cargo.lock を**1コマンドで同期**（`cargo update -p shipsafe --offline` で shipsafe のみ更新）。semver 検証・`v` 接頭辞許容・no-op 検出付き

### `Makefile`（新規）
- `bump` のほか、CONTRIBUTING.md 既出の開発タスク（`build` / `test` / `fmt` / `lint` / `check`）を集約。`make help` で一覧表示

### `CONTRIBUTING.md`
- リリース手順を明文化（`make bump` 起点）

## 検証

- `verify-version` ロジック: 一致 tag(v0.2.1)=exit 0 / bump漏れ tag(v0.2.2)=exit 1（修正手順を表示）
- 冪等チェック: crates.io 実 API で 0.2.1=skip / 未公開=publish
- `make bump VERSION=0.2.2`: Cargo.toml/Cargo.lock の同期を確認（テスト変更は巻き戻し済み）
- スクリプト: shellcheck clean / bash -n ok
- release.yml: YAML 構文・全 needs 依存を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)